### PR TITLE
Re-export 5 star

### DIFF
--- a/src/hero/aramintha.json
+++ b/src/hero/aramintha.json
@@ -155,7 +155,9 @@
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_blaze"]
+            "debuffs": [
+                "stic_blaze"
+            ]
         },
         {
             "isPassive": false,
@@ -233,8 +235,13 @@
                     ]
                 }
             ],
-            "buffs": ["stic_att_up"],
-            "debuffs": ["stic_heal_impossible", "stic_blaze"]
+            "buffs": [
+                "stic_att_up"
+            ],
+            "debuffs": [
+                "stic_heal_impossible",
+                "stic_blaze"
+            ]
         },
         {
             "isPassive": false,
@@ -356,14 +363,20 @@
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_blaze"]
+            "debuffs": [
+                "stic_blaze"
+            ]
         }
     ],
     "specialtySkill": {
         "name": "Leader of Phantom",
         "description": "She is cold-hearted and resolute in achieving her goals.",
-        "dispatch": ["[Strong Leader] Attribute"],
-        "enhancement": ["Reward Bonus +10%"],
+        "dispatch": [
+            "[Strong Leader] Attribute"
+        ],
+        "enhancement": [
+            "Reward Bonus +10%"
+        ],
         "stats": {
             "command": 94,
             "charm": 85,

--- a/src/hero/arbiter-vildred.json
+++ b/src/hero/arbiter-vildred.json
@@ -123,11 +123,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": 3
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": 12000
+                            "qty": 8000
                         }
                     ]
                 },
@@ -140,11 +140,11 @@
                         },
                         {
                             "item": "molagora",
-                            "qty": 4
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": 26000
+                            "qty": 22000
                         }
                     ]
                 },
@@ -156,12 +156,12 @@
                             "qty": 4
                         },
                         {
-                            "item": "molagorago",
-                            "qty": 1
+                            "item": "molagora",
+                            "qty": 5
                         },
                         {
                             "item": "gold",
-                            "qty": 26000
+                            "qty": 40000
                         }
                     ]
                 },
@@ -174,11 +174,11 @@
                         },
                         {
                             "item": "molagorago",
-                            "qty": 2
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": 65000
+                            "qty": 45000
                         }
                     ]
                 },
@@ -190,12 +190,12 @@
                             "qty": 2
                         },
                         {
-                            "item": "molagoragora",
-                            "qty": 1
+                            "item": "molagorago",
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": 160000
+                            "qty": 120000
                         }
                     ]
                 }
@@ -239,12 +239,12 @@
                             "qty": 5
                         },
                         {
-                            "item": "molagorago",
-                            "qty": 2
+                            "item": "molagora",
+                            "qty": 5
                         },
                         {
                             "item": "gold",
-                            "qty": 65000
+                            "qty": 45000
                         }
                     ]
                 },
@@ -256,12 +256,12 @@
                             "qty": 3
                         },
                         {
-                            "item": "molagoragora",
-                            "qty": 1
+                            "item": "molagorago",
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": 190000
+                            "qty": 130000
                         }
                     ]
                 }
@@ -298,11 +298,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": 3
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": 12000
+                            "qty": 8000
                         }
                     ]
                 },
@@ -315,11 +315,11 @@
                         },
                         {
                             "item": "molagora",
-                            "qty": 4
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": 26000
+                            "qty": 22000
                         }
                     ]
                 },
@@ -331,12 +331,12 @@
                             "qty": 4
                         },
                         {
-                            "item": "molagorago",
-                            "qty": 1
+                            "item": "molagora",
+                            "qty": 5
                         },
                         {
                             "item": "gold",
-                            "qty": 26000
+                            "qty": 40000
                         }
                     ]
                 },
@@ -349,11 +349,11 @@
                         },
                         {
                             "item": "molagorago",
-                            "qty": 2
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": 65000
+                            "qty": 45000
                         }
                     ]
                 },
@@ -365,25 +365,31 @@
                             "qty": 2
                         },
                         {
-                            "item": "molagoragora",
-                            "qty": 1
+                            "item": "molagorago",
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": 160000
+                            "qty": 120000
                         }
                     ]
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_blind"]
+            "debuffs": [
+                "stic_blind"
+            ]
         }
     ],
     "specialtySkill": {
         "name": "Irresistible Offer",
         "description": "Neither truth nor lie matters to his offer.",
-        "dispatch": ["[Gourmet] type mission"],
-        "enhancement": ["Reward bonus +10%"],
+        "dispatch": [
+            "[Gourmet] type mission"
+        ],
+        "enhancement": [
+            "Reward bonus +10%"
+        ],
         "stats": {
             "command": 82,
             "charm": 55,

--- a/src/hero/baal-sezan.json
+++ b/src/hero/baal-sezan.json
@@ -77,15 +77,54 @@
             "enhancement": [
                 {
                     "description": "+15% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 19000
+                        }
+                    ]
                 },
                 {
                     "description": "+15% effect chance",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 45000
+                        }
+                    ]
                 },
                 {
                     "description": "+15% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "fused-nerve",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 130000
+                        }
+                    ]
                 }
             ],
             "buffs": [],
@@ -104,26 +143,44 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "ring-of-glory",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 22000
                         }
                     ]
                 },
@@ -131,12 +188,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "ring-of-glory",
+                            "qty": 4
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
                         }
                     ]
                 },
@@ -144,12 +205,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "ring-of-glory",
+                            "qty": 5
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 45000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "fused-nerve",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -170,26 +252,61 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+10% effect chance",
-                    "resources": []
-                },
-                {
-                    "description": "-1 turn cooldown",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "-1 turn cooldown",
+                    "resources": [
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 22000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% effect chance",
+                    "resources": [
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 4
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
                         }
                     ]
                 },
@@ -197,12 +314,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "ring-of-glory",
+                            "qty": 5
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 45000
                         }
                     ]
                 },
@@ -210,12 +331,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "fused-nerve",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -309,7 +434,7 @@
             ],
             "resources": [
                 {
-                    "item": "fire-rune",
+                    "item": "flame-rune",
                     "qty": 10
                 }
             ]
@@ -330,11 +455,11 @@
             ],
             "resources": [
                 {
-                    "item": "fire-rune",
+                    "item": "flame-rune",
                     "qty": 15
                 },
                 {
-                    "item": "greater-fire-rune",
+                    "item": "greater-flame-rune",
                     "qty": 2
                 }
             ]
@@ -352,11 +477,11 @@
             ],
             "resources": [
                 {
-                    "item": "fire-rune",
+                    "item": "flame-rune",
                     "qty": 20
                 },
                 {
-                    "item": "greater-fire-rune",
+                    "item": "greater-flame-rune",
                     "qty": 10
                 }
             ]
@@ -377,11 +502,11 @@
             ],
             "resources": [
                 {
-                    "item": "greater-fire-rune",
+                    "item": "greater-flame-rune",
                     "qty": 10
                 },
                 {
-                    "item": "epic-fire-rune",
+                    "item": "epic-flame-rune",
                     "qty": 2
                 }
             ]
@@ -402,7 +527,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-fire-rune",
+                    "item": "epic-flame-rune",
                     "qty": 6
                 },
                 {
@@ -427,7 +552,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-fire-rune",
+                    "item": "epic-flame-rune",
                     "qty": 10
                 },
                 {

--- a/src/hero/bellona.json
+++ b/src/hero/bellona.json
@@ -89,26 +89,44 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 1
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "slime-jelly",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
                         }
                     ]
                 },
@@ -116,12 +134,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "slime-jelly",
+                            "qty": 7
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "dragons-wrath",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -142,26 +181,44 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 1
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "slime-jelly",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
                         }
                     ]
                 },
@@ -169,12 +226,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "slime-jelly",
+                            "qty": 7
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "dragons-wrath",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -195,26 +273,61 @@
             "enhancement": [
                 {
                     "description": "+15% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% effect chance",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "slime-jelly",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "slime-jelly",
+                            "qty": 7
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
                         }
                     ]
                 },
@@ -222,18 +335,24 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "dragons-wrath",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_def_dn"]
+            "debuffs": [
+                "stic_def_dn"
+            ]
         }
     ],
     "specialtySkill": {
@@ -321,7 +440,7 @@
             ],
             "resources": [
                 {
-                    "item": "earth-rune",
+                    "item": "life-rune",
                     "qty": 10
                 }
             ]
@@ -342,11 +461,11 @@
             ],
             "resources": [
                 {
-                    "item": "earth-rune",
+                    "item": "life-rune",
                     "qty": 15
                 },
                 {
-                    "item": "greater-earth-rune",
+                    "item": "greater-life-rune",
                     "qty": 2
                 }
             ]
@@ -364,11 +483,11 @@
             ],
             "resources": [
                 {
-                    "item": "earth-rune",
+                    "item": "life-rune",
                     "qty": 20
                 },
                 {
-                    "item": "greater-earth-rune",
+                    "item": "greater-life-rune",
                     "qty": 10
                 }
             ]
@@ -389,11 +508,11 @@
             ],
             "resources": [
                 {
-                    "item": "greater-earth-rune",
+                    "item": "greater-life-rune",
                     "qty": 10
                 },
                 {
-                    "item": "epic-earth-rune",
+                    "item": "epic-life-rune",
                     "qty": 2
                 }
             ]
@@ -414,7 +533,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-earth-rune",
+                    "item": "epic-life-rune",
                     "qty": 6
                 },
                 {
@@ -439,7 +558,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-earth-rune",
+                    "item": "epic-life-rune",
                     "qty": 10
                 },
                 {

--- a/src/hero/cecilia.json
+++ b/src/hero/cecilia.json
@@ -96,14 +96,88 @@
             "soulAcquire": 1,
             "description": "Attacks with a spear, with a 35% chance to decrease Defense fo 2 turns. Damage dealt increases proportional to the caster's max Health.",
             "enhancement": [
-                "+5% damage dealt",
-                "+5% effect chance",
-                "+10% damage dealt",
-                "+10% effect chance",
-                "+15% damage dealt"
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
+                },
+                {
+                    "description": "5% effect chance",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "path-power-loop",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% effect chance",
+                    "resources": [
+                        {
+                            "item": "path-power-loop",
+                            "qty": 7
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
+                        }
+                    ]
+                },
+                {
+                    "description": "+15% damage dealt",
+                    "resources": [
+                        {
+                            "item": "nightmare-mask",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
+                        }
+                    ]
+                }
             ],
             "buffs": [],
-            "debuffs": ["stic_def_dn"]
+            "debuffs": [
+                "stic_def_dn"
+            ]
         },
         {
             "isPassive": false,
@@ -115,14 +189,88 @@
             "soulAcquire": 2,
             "description": "Attacks all enemies with a magical spear, with a 35% chance to decrease Attack for 2 turns. The chance increases by 50% when the caster's Health is less than 50%. Damage dealt increases proportional to the caster's max Health.",
             "enhancement": [
-                "+5% damage dealt",
-                "+5% effect chance",
-                "+10% damage dealt",
-                "+10% effect chance",
-                "+15% damage dealt"
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% effect chance",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "path-power-loop",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% effect chance",
+                    "resources": [
+                        {
+                            "item": "path-power-loop",
+                            "qty": 7
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
+                        }
+                    ]
+                },
+                {
+                    "description": "+15% damage dealt",
+                    "resources": [
+                        {
+                            "item": "nightmare-mask",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
+                        }
+                    ]
+                }
             ],
             "buffs": [],
-            "debuffs": ["stic_att_dn"]
+            "debuffs": [
+                "stic_att_dn"
+            ]
         },
         {
             "isPassive": false,
@@ -134,21 +282,101 @@
             "soulAcquire": 2,
             "description": "Attacks all enemies with a spear infused with dark energy, 60% chance to provoke for 1 turn, granting a barrier to the caster for 2 turns. Damage dealt and barrier strength increases proportional to the caster's max Health.",
             "enhancement": [
-                "+10% damage dealt",
-                "+5% effect chance",
-                "-1 turn cooldown",
-                "+10% effect chance",
-                "+15% damage dealt"
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% effect chance",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "-1 turn cooldown",
+                    "resources": [
+                        {
+                            "item": "path-power-loop",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% effect chance",
+                    "resources": [
+                        {
+                            "item": "path-power-loop",
+                            "qty": 7
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
+                        }
+                    ]
+                },
+                {
+                    "description": "+15% damage dealt",
+                    "resources": [
+                        {
+                            "item": "nightmare-mask",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
+                        }
+                    ]
+                }
             ],
-            "buffs": ["stic_protect"],
-            "debuffs": ["stic_provoke"]
+            "buffs": [
+                "stic_protect"
+            ],
+            "debuffs": [
+                "stic_provoke"
+            ]
         }
     ],
     "specialtySkill": {
         "name": "Legacy of Dragon Knight",
         "description": "Having long fought dragons, the Wintenberg dynasty passes down their knowledge via holy scripture.",
-        "dispatch": ["[Gathering] Attribute"],
-        "enhancement": ["Reward bonus +10%"],
+        "dispatch": [
+            "[Gathering] Attribute"
+        ],
+        "enhancement": [
+            "Reward bonus +10%"
+        ],
         "stats": {
             "command": 91,
             "charm": 90,

--- a/src/hero/charlotte.json
+++ b/src/hero/charlotte.json
@@ -77,26 +77,61 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "twisted-fang",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "twisted-fang",
+                            "qty": 7
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
                         }
                     ]
                 },
@@ -104,12 +139,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "blazing-soul",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -130,26 +169,61 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "twisted-fang",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "twisted-fang",
+                            "qty": 7
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
                         }
                     ]
                 },
@@ -157,12 +231,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "blazing-soul",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -183,26 +261,44 @@
             "enhancement": [
                 {
                     "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
-                },
-                {
-                    "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "twisted-fang",
+                            "qty": 5
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
                         }
                     ]
                 },
@@ -210,12 +306,33 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "twisted-fang",
+                            "qty": 7
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
+                        }
+                    ]
+                },
+                {
+                    "description": "+15% damage dealt",
+                    "resources": [
+                        {
+                            "item": "blazing-soul",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -309,7 +426,7 @@
             ],
             "resources": [
                 {
-                    "item": "fire-rune",
+                    "item": "flame-rune",
                     "qty": 10
                 }
             ]
@@ -330,11 +447,11 @@
             ],
             "resources": [
                 {
-                    "item": "fire-rune",
+                    "item": "flame-rune",
                     "qty": 15
                 },
                 {
-                    "item": "greater-fire-rune",
+                    "item": "greater-flame-rune",
                     "qty": 2
                 }
             ]
@@ -352,11 +469,11 @@
             ],
             "resources": [
                 {
-                    "item": "fire-rune",
+                    "item": "flame-rune",
                     "qty": 20
                 },
                 {
-                    "item": "greater-fire-rune",
+                    "item": "greater-flame-rune",
                     "qty": 10
                 }
             ]
@@ -377,11 +494,11 @@
             ],
             "resources": [
                 {
-                    "item": "greater-fire-rune",
+                    "item": "greater-flame-rune",
                     "qty": 10
                 },
                 {
-                    "item": "epic-fire-rune",
+                    "item": "epic-flame-rune",
                     "qty": 2
                 }
             ]
@@ -402,7 +519,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-fire-rune",
+                    "item": "epic-flame-rune",
                     "qty": 6
                 },
                 {
@@ -427,7 +544,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-fire-rune",
+                    "item": "epic-flame-rune",
                     "qty": 10
                 },
                 {

--- a/src/hero/chloe.json
+++ b/src/hero/chloe.json
@@ -77,26 +77,27 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
@@ -104,12 +105,50 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "archers-vision",
+                            "qty": 5
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "archers-vision",
+                            "qty": 7
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "mercendarys-medicine",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -130,26 +169,27 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
@@ -157,12 +197,50 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "archers-vision",
+                            "qty": 5
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "archers-vision",
+                            "qty": 7
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "mercendarys-medicine",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -183,26 +261,44 @@
             "enhancement": [
                 {
                     "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
-                },
-                {
-                    "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "archers-vision",
+                            "qty": 5
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
                         }
                     ]
                 },
@@ -210,12 +306,33 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "archers-vision",
+                            "qty": 7
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
+                        }
+                    ]
+                },
+                {
+                    "description": "+15% damage dealt",
+                    "resources": [
+                        {
+                            "item": "mercendarys-medicine",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -309,7 +426,7 @@
             ],
             "resources": [
                 {
-                    "item": "ice-rune",
+                    "item": "frost-rune",
                     "qty": 10
                 }
             ]
@@ -330,11 +447,11 @@
             ],
             "resources": [
                 {
-                    "item": "ice-rune",
+                    "item": "frost-rune",
                     "qty": 15
                 },
                 {
-                    "item": "greater-ice-rune",
+                    "item": "greater-frost-rune",
                     "qty": 2
                 }
             ]
@@ -352,11 +469,11 @@
             ],
             "resources": [
                 {
-                    "item": "ice-rune",
+                    "item": "frost-rune",
                     "qty": 20
                 },
                 {
-                    "item": "greater-ice-rune",
+                    "item": "greater-frost-rune",
                     "qty": 10
                 }
             ]
@@ -377,11 +494,11 @@
             ],
             "resources": [
                 {
-                    "item": "greater-ice-rune",
+                    "item": "greater-frost-rune",
                     "qty": 10
                 },
                 {
-                    "item": "epic-ice-rune",
+                    "item": "epic-frost-rune",
                     "qty": 2
                 }
             ]
@@ -402,7 +519,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-ice-rune",
+                    "item": "epic-frost-rune",
                     "qty": 6
                 },
                 {
@@ -427,7 +544,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-ice-rune",
+                    "item": "epic-frost-rune",
                     "qty": 10
                 },
                 {

--- a/src/hero/dark-corvus.json
+++ b/src/hero/dark-corvus.json
@@ -92,11 +92,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "4000"
+                            "qty": 4000
                         }
                     ]
                 },
@@ -105,11 +105,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": "8000"
+                            "qty": 8000
                         }
                     ]
                 },
@@ -118,15 +118,15 @@
                     "resources": [
                         {
                             "item": "slime-jelly",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "molagora",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "22000"
+                            "qty": 22000
                         }
                     ]
                 },
@@ -135,15 +135,15 @@
                     "resources": [
                         {
                             "item": "slime-jelly",
-                            "qty": "4"
+                            "qty": 4
                         },
                         {
                             "item": "molagora",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "gold",
-                            "qty": "40000"
+                            "qty": 40000
                         }
                     ]
                 },
@@ -152,15 +152,15 @@
                     "resources": [
                         {
                             "item": "slime-jelly",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "molagorago",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "45000"
+                            "qty": 45000
                         }
                     ]
                 },
@@ -169,21 +169,23 @@
                     "resources": [
                         {
                             "item": "dragons-wrath",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "molagorago",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "120000"
+                            "qty": 120000
                         }
                     ]
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_provoke"]
+            "debuffs": [
+                "stic_provoke"
+            ]
         },
         {
             "isPassive": true,
@@ -201,15 +203,15 @@
                     "resources": [
                         {
                             "item": "slime-jelly",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "molagora",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "19000"
+                            "qty": 19000
                         }
                     ]
                 },
@@ -218,15 +220,15 @@
                     "resources": [
                         {
                             "item": "slime-jelly",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "molagora",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "gold",
-                            "qty": "45000"
+                            "qty": 45000
                         }
                     ]
                 },
@@ -235,15 +237,15 @@
                     "resources": [
                         {
                             "item": "dragons-wrath",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "molagorago",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": "130000"
+                            "qty": 130000
                         }
                     ]
                 }
@@ -267,11 +269,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "4000"
+                            "qty": 4000
                         }
                     ]
                 },
@@ -280,11 +282,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": "8000"
+                            "qty": 8000
                         }
                     ]
                 },
@@ -293,15 +295,15 @@
                     "resources": [
                         {
                             "item": "slime-jelly",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "molagora",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "22000"
+                            "qty": 22000
                         }
                     ]
                 },
@@ -310,15 +312,15 @@
                     "resources": [
                         {
                             "item": "slime-jelly",
-                            "qty": "4"
+                            "qty": 4
                         },
                         {
                             "item": "molagora",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "gold",
-                            "qty": "40000"
+                            "qty": 40000
                         }
                     ]
                 },
@@ -327,15 +329,15 @@
                     "resources": [
                         {
                             "item": "slime-jelly",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "molagorago",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "45000"
+                            "qty": 45000
                         }
                     ]
                 },
@@ -344,15 +346,15 @@
                     "resources": [
                         {
                             "item": "dragons-wrath",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "molagorago",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "120000"
+                            "qty": 120000
                         }
                     ]
                 }
@@ -447,7 +449,7 @@
             "resources": [
                 {
                     "item": "dark-rune",
-                    "qty": "10"
+                    "qty": 10
                 }
             ]
         },
@@ -468,11 +470,11 @@
             "resources": [
                 {
                     "item": "dark-rune",
-                    "qty": "15"
+                    "qty": 15
                 },
                 {
                     "item": "greater-dark-rune",
-                    "qty": "2"
+                    "qty": 2
                 }
             ]
         },
@@ -490,11 +492,11 @@
             "resources": [
                 {
                     "item": "dark-rune",
-                    "qty": "20"
+                    "qty": 20
                 },
                 {
                     "item": "greater-dark-rune",
-                    "qty": "10"
+                    "qty": 10
                 }
             ]
         },
@@ -515,11 +517,11 @@
             "resources": [
                 {
                     "item": "greater-dark-rune",
-                    "qty": "10"
+                    "qty": 10
                 },
                 {
                     "item": "epic-dark-rune",
-                    "qty": "2"
+                    "qty": 2
                 }
             ]
         },
@@ -540,11 +542,11 @@
             "resources": [
                 {
                     "item": "epic-dark-rune",
-                    "qty": "6"
+                    "qty": 6
                 },
                 {
                     "item": "cursed-ashes",
-                    "qty": "15"
+                    "qty": 15
                 }
             ]
         },
@@ -565,11 +567,11 @@
             "resources": [
                 {
                     "item": "epic-dark-rune",
-                    "qty": "10"
+                    "qty": 10
                 },
                 {
                     "item": "dragons-wrath",
-                    "qty": "10"
+                    "qty": 10
                 }
             ]
         }

--- a/src/hero/destina.json
+++ b/src/hero/destina.json
@@ -100,11 +100,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "4000"
+                            "qty": 4000
                         }
                     ]
                 },
@@ -113,11 +113,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": "8000"
+                            "qty": 8000
                         }
                     ]
                 },
@@ -126,15 +126,15 @@
                     "resources": [
                         {
                             "item": "baby-mouse-insignia",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "molagora",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "22000"
+                            "qty": 22000
                         }
                     ]
                 },
@@ -143,15 +143,15 @@
                     "resources": [
                         {
                             "item": "baby-mouse-insignia",
-                            "qty": "4"
+                            "qty": 4
                         },
                         {
                             "item": "molagora",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "gold",
-                            "qty": "40000"
+                            "qty": 40000
                         }
                     ]
                 },
@@ -160,15 +160,15 @@
                     "resources": [
                         {
                             "item": "baby-mouse-insignia",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "molagorago",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "45000"
+                            "qty": 45000
                         }
                     ]
                 },
@@ -177,15 +177,15 @@
                     "resources": [
                         {
                             "item": "the-heart-of-hypocrisy",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "molagorago",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "120000"
+                            "qty": 120000
                         }
                     ]
                 }
@@ -209,15 +209,15 @@
                     "resources": [
                         {
                             "item": "baby-mouse-insignia",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "molagora",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "19000"
+                            "qty": 19000
                         }
                     ]
                 },
@@ -226,15 +226,15 @@
                     "resources": [
                         {
                             "item": "baby-mouse-insignia",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "molagora",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "gold",
-                            "qty": "45000"
+                            "qty": 45000
                         }
                     ]
                 },
@@ -243,15 +243,15 @@
                     "resources": [
                         {
                             "item": "the-heart-of-hypocrisy",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "molagorago",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": "130000"
+                            "qty": 130000
                         }
                     ]
                 }
@@ -275,11 +275,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "4000"
+                            "qty": 4000
                         }
                     ]
                 },
@@ -288,11 +288,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": "8000"
+                            "qty": 8000
                         }
                     ]
                 },
@@ -301,15 +301,15 @@
                     "resources": [
                         {
                             "item": "baby-mouse-insignia",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "molagora",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "22000"
+                            "qty": 22000
                         }
                     ]
                 },
@@ -318,15 +318,15 @@
                     "resources": [
                         {
                             "item": "baby-mouse-insignia",
-                            "qty": "4"
+                            "qty": 4
                         },
                         {
                             "item": "molagora",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "gold",
-                            "qty": "40000"
+                            "qty": 40000
                         }
                     ]
                 },
@@ -335,15 +335,15 @@
                     "resources": [
                         {
                             "item": "baby-mouse-insignia",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "molagorago",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "45000"
+                            "qty": 45000
                         }
                     ]
                 },
@@ -352,15 +352,15 @@
                     "resources": [
                         {
                             "item": "the-heart-of-hypocrisy",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "molagorago",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "120000"
+                            "qty": 120000
                         }
                     ]
                 }
@@ -449,7 +449,7 @@
             "resources": [
                 {
                     "item": "life-rune",
-                    "qty": "10"
+                    "qty": 10
                 }
             ]
         },
@@ -470,11 +470,11 @@
             "resources": [
                 {
                     "item": "life-rune",
-                    "qty": "15"
+                    "qty": 15
                 },
                 {
                     "item": "greater-life-rune",
-                    "qty": "2"
+                    "qty": 2
                 }
             ]
         },
@@ -492,11 +492,11 @@
             "resources": [
                 {
                     "item": "life-rune",
-                    "qty": "20"
+                    "qty": 20
                 },
                 {
                     "item": "greater-life-rune",
-                    "qty": "10"
+                    "qty": 10
                 }
             ]
         },
@@ -517,11 +517,11 @@
             "resources": [
                 {
                     "item": "greater-life-rune",
-                    "qty": "10"
+                    "qty": 10
                 },
                 {
                     "item": "epic-life-rune",
-                    "qty": "2"
+                    "qty": 2
                 }
             ]
         },
@@ -542,11 +542,11 @@
             "resources": [
                 {
                     "item": "epic-life-rune",
-                    "qty": "6"
+                    "qty": 6
                 },
                 {
                     "item": "special-alarm-loop",
-                    "qty": "15"
+                    "qty": 15
                 }
             ]
         },
@@ -567,11 +567,11 @@
             "resources": [
                 {
                     "item": "epic-life-rune",
-                    "qty": "10"
+                    "qty": 10
                 },
                 {
                     "item": "the-heart-of-hypocrisy",
-                    "qty": "10"
+                    "qty": 10
                 }
             ]
         }

--- a/src/hero/diene.json
+++ b/src/hero/diene.json
@@ -118,12 +118,12 @@
                     "description": "+2% combat readiness",
                     "resources": [
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": 0
+                            "qty": 8000
                         }
                     ]
                 },
@@ -131,12 +131,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": 0
+                            "qty": 12000
                         }
                     ]
                 },
@@ -144,12 +144,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "ring-of-glory",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": 0
+                            "qty": 27000
                         }
                     ]
                 },
@@ -157,12 +161,16 @@
                     "description": "+3% combat readiness",
                     "resources": [
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "ring-of-glory",
+                            "qty": 4
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
                         },
                         {
                             "item": "gold",
-                            "qty": 0
+                            "qty": 40000
                         }
                     ]
                 },
@@ -170,12 +178,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "ring-of-glory",
+                            "qty": 7
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": 0
+                            "qty": 55000
                         }
                     ]
                 },
@@ -183,12 +195,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "fused-nerve",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": 0
+                            "qty": 150000
                         }
                     ]
                 }
@@ -225,11 +241,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": 3
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": 0
+                            "qty": 8000
                         }
                     ]
                 },
@@ -237,12 +253,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "ring-of-glory",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": 0
+                            "qty": 22000
                         }
                     ]
                 },
@@ -250,12 +270,16 @@
                     "description": "+10% barrier strength",
                     "resources": [
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "ring-of-glory",
+                            "qty": 4
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
                         },
                         {
                             "item": "gold",
-                            "qty": 0
+                            "qty": 40000
                         }
                     ]
                 },
@@ -263,12 +287,16 @@
                     "description": "+15% barrier strength",
                     "resources": [
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "ring-of-glory",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": 0
+                            "qty": 45000
                         }
                     ]
                 },
@@ -276,17 +304,23 @@
                     "description": "+15% barrier strength",
                     "resources": [
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "fused-nerve",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": 0
+                            "qty": 120000
                         }
                     ]
                 }
             ],
-            "buffs": ["stic_protect"],
+            "buffs": [
+                "stic_protect"
+            ],
             "debuffs": []
         },
         {
@@ -304,12 +338,12 @@
                     "description": "Acquire +1 soul",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 3
-                        },
-                        {
                             "item": "ring-of-glory",
                             "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
                         },
                         {
                             "item": "gold",
@@ -321,29 +355,36 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "fused-nerve",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": 0
+                            "qty": 100000
                         }
                     ]
                 }
             ],
-            "buffs": ["stic_att_up", "stic_cri_res_up"],
+            "buffs": [
+                "stic_att_up",
+                "stic_cri_res_up"
+            ],
             "debuffs": []
         }
     ],
     "specialtySkill": {
         "name": "Saint of Ezera",
         "description": "She overcomes the hardship through her deeply pious faith.",
-        "dispatch": ["[Support] Type"],
-        "enhancement": ["Reward bonus +6%"],
+        "dispatch": [
+            "[Support] Type"
+        ],
+        "enhancement": [
+            "Reward bonus +6%"
+        ],
         "stats": {
             "command": 78,
             "charm": 86,

--- a/src/hero/haste.json
+++ b/src/hero/haste.json
@@ -77,26 +77,44 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% effect chance",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "ring-of-glory",
+                            "qty": 5
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
                         }
                     ]
                 },
@@ -104,12 +122,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "ring-of-glory",
+                            "qty": 7
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "fused-nerve",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -130,26 +169,61 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+15% healing",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
+                        }
+                    ]
+                },
+                {
+                    "description": "+15% healing",
+                    "resources": [
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 7
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
                         }
                     ]
                 },
@@ -157,12 +231,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "fused-nerve",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -183,26 +261,61 @@
             "enhancement": [
                 {
                     "description": "+15% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% effect chance",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "ring-of-glory",
+                            "qty": 7
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
                         }
                     ]
                 },
@@ -210,12 +323,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "fused-nerve",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -309,7 +426,7 @@
             ],
             "resources": [
                 {
-                    "item": "fire-rune",
+                    "item": "flame-rune",
                     "qty": 10
                 }
             ]
@@ -330,11 +447,11 @@
             ],
             "resources": [
                 {
-                    "item": "fire-rune",
+                    "item": "flame-rune",
                     "qty": 15
                 },
                 {
-                    "item": "greater-fire-rune",
+                    "item": "greater-flame-rune",
                     "qty": 2
                 }
             ]
@@ -352,11 +469,11 @@
             ],
             "resources": [
                 {
-                    "item": "fire-rune",
+                    "item": "flame-rune",
                     "qty": 20
                 },
                 {
-                    "item": "greater-fire-rune",
+                    "item": "greater-flame-rune",
                     "qty": 10
                 }
             ]
@@ -377,11 +494,11 @@
             ],
             "resources": [
                 {
-                    "item": "greater-fire-rune",
+                    "item": "greater-flame-rune",
                     "qty": 10
                 },
                 {
-                    "item": "epic-fire-rune",
+                    "item": "epic-flame-rune",
                     "qty": 2
                 }
             ]
@@ -402,7 +519,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-fire-rune",
+                    "item": "epic-flame-rune",
                     "qty": 6
                 },
                 {
@@ -427,7 +544,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-fire-rune",
+                    "item": "epic-flame-rune",
                     "qty": 10
                 },
                 {

--- a/src/hero/iseria.json
+++ b/src/hero/iseria.json
@@ -77,26 +77,57 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% effect chance",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 12000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "twisted-fang",
+                            "qty": 3
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 27000
                         }
                     ]
                 },
@@ -104,12 +135,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "twisted-fang",
+                            "qty": 4
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
                         }
                     ]
                 },
@@ -117,12 +152,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "twisted-fang",
+                            "qty": 7
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
                         }
                     ]
                 },
@@ -130,12 +169,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "blazing-soul",
+                            "qty": 3
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 150000
                         }
                     ]
                 }
@@ -156,11 +199,37 @@
             "enhancement": [
                 {
                     "description": "+2 Soul acquired",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "twisted-fang",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "blazing-soul",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
+                        }
+                    ]
                 }
             ],
             "buffs": [],
@@ -179,26 +248,44 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "twisted-fang",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 22000
                         }
                     ]
                 },
@@ -206,12 +293,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "twisted-fang",
+                            "qty": 4
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
                         }
                     ]
                 },
@@ -219,12 +310,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "twisted-fang",
+                            "qty": 5
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 45000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "blazing-soul",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -318,7 +430,7 @@
             ],
             "resources": [
                 {
-                    "item": "earth-rune",
+                    "item": "life-rune",
                     "qty": 10
                 }
             ]
@@ -339,11 +451,11 @@
             ],
             "resources": [
                 {
-                    "item": "earth-rune",
+                    "item": "life-rune",
                     "qty": 15
                 },
                 {
-                    "item": "greater-earth-rune",
+                    "item": "greater-life-rune",
                     "qty": 2
                 }
             ]
@@ -361,11 +473,11 @@
             ],
             "resources": [
                 {
-                    "item": "earth-rune",
+                    "item": "life-rune",
                     "qty": 20
                 },
                 {
-                    "item": "greater-earth-rune",
+                    "item": "greater-life-rune",
                     "qty": 10
                 }
             ]
@@ -386,11 +498,11 @@
             ],
             "resources": [
                 {
-                    "item": "greater-earth-rune",
+                    "item": "greater-life-rune",
                     "qty": 10
                 },
                 {
-                    "item": "epic-earth-rune",
+                    "item": "epic-life-rune",
                     "qty": 2
                 }
             ]
@@ -411,7 +523,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-earth-rune",
+                    "item": "epic-life-rune",
                     "qty": 6
                 },
                 {
@@ -436,7 +548,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-earth-rune",
+                    "item": "epic-life-rune",
                     "qty": 10
                 },
                 {

--- a/src/hero/judge-kise.json
+++ b/src/hero/judge-kise.json
@@ -119,11 +119,11 @@
                         },
                         {
                             "item": "molagora",
-                            "qty": "4"
+                            "qty": 4
                         },
                         {
                             "item": "gold",
-                            "qty": "31000"
+                            "qty": 31000
                         }
                     ]
                 },
@@ -136,11 +136,11 @@
                         },
                         {
                             "item": "molagora",
-                            "qty": "7"
+                            "qty": 7
                         },
                         {
                             "item": "gold",
-                            "qty": "53000"
+                            "qty": 53000
                         }
                     ]
                 },
@@ -153,17 +153,19 @@
                         },
                         {
                             "item": "molagorago",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": "100000"
+                            "qty": 100000
                         }
                     ]
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_def_dn"]
+            "debuffs": [
+                "stic_def_dn"
+            ]
         },
         {
             "isPassive": false,
@@ -198,11 +200,11 @@
                         },
                         {
                             "item": "molagora",
-                            "qty": "4"
+                            "qty": 4
                         },
                         {
                             "item": "gold",
-                            "qty": "31000"
+                            "qty": 31000
                         }
                     ]
                 },
@@ -215,11 +217,11 @@
                         },
                         {
                             "item": "molagora",
-                            "qty": "7"
+                            "qty": 7
                         },
                         {
                             "item": "gold",
-                            "qty": "53000"
+                            "qty": 53000
                         }
                     ]
                 },
@@ -232,11 +234,11 @@
                         },
                         {
                             "item": "molagorago",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": "100000"
+                            "qty": 100000
                         }
                     ]
                 }
@@ -303,11 +305,11 @@
                         },
                         {
                             "item": "molagora",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "27000"
+                            "qty": 27000
                         }
                     ]
                 },
@@ -320,11 +322,11 @@
                         },
                         {
                             "item": "molagora",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "gold",
-                            "qty": "40000"
+                            "qty": 40000
                         }
                     ]
                 },
@@ -337,11 +339,11 @@
                         },
                         {
                             "item": "molagorago",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "55000"
+                            "qty": 55000
                         }
                     ]
                 },
@@ -354,11 +356,11 @@
                         },
                         {
                             "item": "molagorago",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "150000"
+                            "qty": 150000
                         }
                     ]
                 }
@@ -370,8 +372,12 @@
     "specialtySkill": {
         "name": "Fate Watcher",
         "description": "Facing her fate, she carries out her duty.",
-        "dispatch": ["[Fear] type mission"],
-        "enhancement": ["Reward bonus +10%"],
+        "dispatch": [
+            "[Fear] type mission"
+        ],
+        "enhancement": [
+            "Reward bonus +10%"
+        ],
         "stats": {
             "command": 95,
             "charm": 87,

--- a/src/hero/kayron.json
+++ b/src/hero/kayron.json
@@ -1,0 +1,547 @@
+{
+    "name": "Kayron",
+    "rarity": 5,
+    "classType": "thief",
+    "element": "fire",
+    "zodiac": "aries",
+    "specialtyChangeName": "",
+    "selfSkillBarName": "",
+    "background": "An Acolyte, and commander of an army of undead known as the Dust Walkers. It is said that he demands your soul and loyalty in return for releasing you from your grudges.",
+    "relations": [
+        {
+            "hero": "",
+            "relationType": ""
+        }
+    ],
+    "stats": {
+        "base": {
+            "cp": 0,
+            "atk": 0,
+            "hp": 0,
+            "spd": 0,
+            "def": 0,
+            "chc": 0,
+            "chd": 0,
+            "eff": 0,
+            "efr": 0,
+            "dac": 0
+        },
+        "max": {
+            "cp": 0,
+            "atk": 0,
+            "hp": 0,
+            "spd": 0,
+            "def": 0,
+            "chc": 0,
+            "chd": 0,
+            "eff": 0,
+            "efr": 0,
+            "dac": 5
+        }
+    },
+    "skills": [
+        {
+            "isPassive": false,
+            "soulBurn": 10,
+            "selfSkillBarValue": 0,
+            "soulBurnEffect": "Increases damage dealt.",
+            "awakenUpgrade": false,
+            "cooldown": 0,
+            "name": "Void Slash",
+            "soulAcquire": 1,
+            "description": "Attacks with a sword, with a 35% chance to decrease Hit Chance for 1 turn, dealing damage proportional to the caster's lost Health.",
+            "enhancement": [
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% effect chance",
+                    "resources": [
+                        {
+                            "item": "path-power-loop",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 22000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "path-power-loop",
+                            "qty": 4
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% effect chance",
+                    "resources": [
+                        {
+                            "item": "path-power-loop",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 45000
+                        }
+                    ]
+                },
+                {
+                    "description": "+15% damage dealt",
+                    "resources": [
+                        {
+                            "item": "nightmare-mask",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
+                        }
+                    ]
+                }
+            ],
+            "buffs": [],
+            "debuffs": [
+                "stic_blind"
+            ]
+        },
+        {
+            "isPassive": true,
+            "soulBurn": 0,
+            "selfSkillBarValue": 0,
+            "soulBurnEffect": "",
+            "awakenUpgrade": false,
+            "cooldown": 0,
+            "name": "Immortal Will",
+            "soulAcquire": 0,
+            "description": "Grants immortality for 1 turn when the caster receives lethal damage and resets skill cooldown of Apocalypse.\nCan only be activated once every 9 turn(s).\nOn the caster's turn, when buffed and using Void Slash, the skill will become an AoE attack and does not trigger Dual Attack.",
+            "enhancement": [
+                {
+                    "description": "-1 turn cooldown",
+                    "resources": [
+                        {
+                            "item": "path-power-loop",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 19000
+                        }
+                    ]
+                },
+                {
+                    "description": "-1 turn cooldown",
+                    "resources": [
+                        {
+                            "item": "path-power-loop",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 45000
+                        }
+                    ]
+                },
+                {
+                    "description": "-1 turn cooldown",
+                    "resources": [
+                        {
+                            "item": "nightmare-mask",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 130000
+                        }
+                    ]
+                }
+            ],
+            "buffs": [
+                "stic_immortal"
+            ],
+            "debuffs": []
+        },
+        {
+            "isPassive": false,
+            "soulBurn": 0,
+            "selfSkillBarValue": 0,
+            "soulBurnEffect": "",
+            "awakenUpgrade": true,
+            "cooldown": 6,
+            "name": "Apocalypse",
+            "soulAcquire": 3,
+            "description": "Attacks the enemy by exploding the Archdemon's Might contained within their sword, increasing Attack of the caster for 2 turns. If the enemy is defeated, extends any buffs granted to the caster by 1 turn. Deals damage proportional to the caster's lost Health.",
+            "enhancement": [
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "-1 turn cooldown",
+                    "resources": [
+                        {
+                            "item": "path-power-loop",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 22000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "path-power-loop",
+                            "qty": 4
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "path-power-loop",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 45000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "nightmare-mask",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
+                        }
+                    ]
+                }
+            ],
+            "buffs": [
+                "stic_att_up"
+            ],
+            "debuffs": []
+        }
+    ],
+    "specialtySkill": {
+        "name": "Desire for Ruin",
+        "description": "He destroys everything with his army of Dust Walkers, yearning for the annihilation of the world.",
+        "dispatch": [],
+        "enhancement": [],
+        "stats": {
+            "command": 94,
+            "charm": 81,
+            "politics": 75
+        }
+    },
+    "memoryImprintFormation": {
+        "north": false,
+        "south": false,
+        "east": false,
+        "west": false
+    },
+    "memoryImprint": [
+        {
+            "rank": "d",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
+        },
+        {
+            "rank": "c",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
+        },
+        {
+            "rank": "b",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
+        },
+        {
+            "rank": "a",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
+        },
+        {
+            "rank": "s",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
+        },
+        {
+            "rank": "ss",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
+        },
+        {
+            "rank": "sss",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
+        }
+    ],
+    "awakening": [
+        {
+            "rank": 1,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "": 0
+                },
+                {
+                    "atk": 20
+                },
+                {
+                    "hp": 60
+                }
+            ],
+            "resources": [
+                {
+                    "item": "flame-rune",
+                    "qty": 10
+                }
+            ]
+        },
+        {
+            "rank": 2,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "": 0
+                },
+                {
+                    "atk": 20
+                },
+                {
+                    "hp": 60
+                }
+            ],
+            "resources": [
+                {
+                    "item": "flame-rune",
+                    "qty": 15
+                },
+                {
+                    "item": "greater-flame-rune",
+                    "qty": 2
+                }
+            ]
+        },
+        {
+            "rank": 3,
+            "skillUpgrade": true,
+            "statsIncrease": [
+                {
+                    "atk": 20
+                },
+                {
+                    "hp": 60
+                }
+            ],
+            "resources": [
+                {
+                    "item": "flame-rune",
+                    "qty": 20
+                },
+                {
+                    "item": "greater-flame-rune",
+                    "qty": 10
+                }
+            ]
+        },
+        {
+            "rank": 4,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "": 0
+                },
+                {
+                    "atk": 30
+                },
+                {
+                    "hp": 80
+                }
+            ],
+            "resources": [
+                {
+                    "item": "greater-flame-rune",
+                    "qty": 10
+                },
+                {
+                    "item": "epic-flame-rune",
+                    "qty": 2
+                }
+            ]
+        },
+        {
+            "rank": 5,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "": 0
+                },
+                {
+                    "atk": 30
+                },
+                {
+                    "hp": 80
+                }
+            ],
+            "resources": [
+                {
+                    "item": "epic-flame-rune",
+                    "qty": 6
+                },
+                {
+                    "item": "blessing-of-orbis",
+                    "qty": 15
+                }
+            ]
+        },
+        {
+            "rank": 6,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "": 0
+                },
+                {
+                    "atk": 30
+                },
+                {
+                    "hp": 80
+                }
+            ],
+            "resources": [
+                {
+                    "item": "epic-flame-rune",
+                    "qty": 10
+                },
+                {
+                    "item": "nightmare-mask",
+                    "qty": 10
+                }
+            ]
+        }
+    ]
+}

--- a/src/hero/ken.json
+++ b/src/hero/ken.json
@@ -1,443 +1,568 @@
 {
-  "name": "Ken",
-  "rarity": 5,
-  "classType": "warrior",
-  "element": "fire",
-  "zodiac": "capricorn",
-  "specialtyChangeName": "",
-  "selfSkillBarName": "fighting-spirit",
-  "background": "Born an orphan, Ken has faced many hardships in his life, but manages to maintain a bright and optimistic personality. He believes the only way to survive is through strength, and dedicates his life to training and always admires the strong.",
-  "relations": [
-    {
-      "hero": "",
-      "relationType": ""
-    }
-  ],
-  "stats": {
-    "base": {
-      "cp": 0,
-      "atk": 0,
-      "hp": 0,
-      "spd": 0,
-      "def": 0,
-      "chc": 0,
-      "chd": 0,
-      "eff": 0,
-      "efr": 0,
-      "dac": 0
-    },
-    "max": {
-      "cp": 0,
-      "atk": 0,
-      "hp": 0,
-      "spd": 0,
-      "def": 0,
-      "chc": 0,
-      "chd": 0,
-      "eff": 0,
-      "efr": 0,
-      "dac": 5
-    },
-    "max6": {
-      "chc": 15,
-      "chd": 150,
-      "eff": 0,
-      "dac": 5,
-      "hp": 5850,
-      "cp": 15038,
-      "spd": 102,
-      "atk": 816,
-      "def": 620,
-      "efr": 0
-    },
-    "max5": {
-      "chc": 15,
-      "chd": 150,
-      "eff": 0,
-      "dac": 5,
-      "hp": 4653,
-      "cp": 12050,
-      "spd": 102,
-      "atk": 655,
-      "def": 500,
-      "efr": 0
-    }
-  },
-  "skills": [
-    {
-      "isPassive": false,
-      "soulBurn": 0,
-      "selfSkillBarValue": 15,
-      "soulBurnEffect": "",
-      "awakenUpgrade": false,
-      "cooldown": 0,
-      "name": "Knockout",
-      "soulAcquire": 1,
-      "description": "Attacks with a flurry of strikes, with a 35% chance to decrease Defense for 2 turns. If the caster is granted Vigor, also burns target for 2 turns. Damage dealt increases proportional to the caster's max Health.",
-      "enhancement": [
+    "name": "Ken",
+    "rarity": 5,
+    "classType": "warrior",
+    "element": "fire",
+    "zodiac": "capricorn",
+    "specialtyChangeName": "",
+    "selfSkillBarName": "fighting-spirit",
+    "background": "Born an orphan, Ken has faced many hardships in his life, but manages to maintain a bright and optimistic personality. He believes the only way to survive is through strength, and dedicates his life to training and always admires the strong.",
+    "relations": [
         {
-          "description": "+5% damage dealt",
-          "resources": []
-        },
-        {
-          "description": "+5% damage dealt",
-          "resources": []
-        },
-        {
-          "description": "+5 Fighting Spirit acquired",
-          "resources": []
-        },
-        {
-          "description": "+5% damage dealt",
-          "resources": [
-            {
-              "item": "gold",
-              "qty": 0
-            },
-            {
-              "item": "",
-              "qty": 0
-            }
-          ]
-        },
-        {
-          "description": "+5% damage dealt",
-          "resources": [
-            {
-              "item": "gold",
-              "qty": 0
-            },
-            {
-              "item": "",
-              "qty": 0
-            }
-          ]
-        },
-        {
-          "description": "+10% damage dealt",
-          "resources": [
-            {
-              "item": "gold",
-              "qty": 0
-            },
-            {
-              "item": "",
-              "qty": 0
-            }
-          ]
+            "hero": "",
+            "relationType": ""
         }
-      ],
-      "buffs": [],
-      "debuffs": [
-        "stic_def_dn",
-        "stic_blaze"
-      ]
-    },
-    {
-      "isPassive": false,
-      "soulBurn": 20,
-      "selfSkillBarValue": 0,
-      "soulBurnEffect": "Grants an extra turn.",
-      "awakenUpgrade": false,
-      "cooldown": 3,
-      "name": "Celestial Kick",
-      "soulAcquire": 2,
-      "description": "Attacks the enemy with a kick, increasing Speed of the caster for 2 turns, with a 75% chance to decrease Defense of the target for 2 turns. Gains 40 Fighting Spirit when an enemy is defeated. If caster is granted Vigor, ignores Effect Resistance. Damage dealt increases proportional to the caster's max Health.",
-      "enhancement": [
-        {
-          "description": "+5% damage dealt",
-          "resources": []
-        },
-        {
-          "description": "+10% damage dealt",
-          "resources": []
-        },
-        {
-          "description": "+15% damage dealt",
-          "resources": []
-        }
-      ],
-      "buffs": [],
-      "debuffs": []
-    },
-    {
-      "isPassive": false,
-      "soulBurn": 0,
-      "selfSkillBarValue": -100,
-      "soulBurnEffect": "",
-      "awakenUpgrade": true,
-      "cooldown": 6,
-      "name": "Phoenix Flurry",
-      "soulAcquire": 3,
-      "description": "Delivers a powerful blow after a flurry of strikes, stunning for 1 turn and decreasing Attack for 2 turns, before granting Vigor to the caster for 4 turns. Damage dealt increases proportional to the caster's max Health. Caster begins the first battle with 50 Fighting Spirit, and gains 5 Fighting Spirit when attacked.",
-      "enhancement": [
-        {
-          "description": "+5% damage dealt",
-          "resources": []
-        },
-        {
-          "description": "+5% damage dealt",
-          "resources": []
-        },
-        {
-          "description": "-1 turn cooldown",
-          "resources": []
-        },
-        {
-          "description": "+5% damage dealt",
-          "resources": [
-            {
-              "item": "gold",
-              "qty": 0
-            },
-            {
-              "item": "",
-              "qty": 0
-            }
-          ]
-        },
-        {
-          "description": "+10% damage dealt",
-          "resources": [
-            {
-              "item": "gold",
-              "qty": 0
-            },
-            {
-              "item": "",
-              "qty": 0
-            }
-          ]
-        },
-        {
-          "description": "+15% damage dealt",
-          "resources": [
-            {
-              "item": "gold",
-              "qty": 0
-            },
-            {
-              "item": "",
-              "qty": 0
-            }
-          ]
-        }
-      ],
-      "buffs": [],
-      "debuffs": []
-    }
-  ],
-  "specialtySkill": {
-    "name": "Victory Is Ours",
-    "description": "Exuding confidence, no one can defeat him in this battle.",
-    "dispatch": [],
-    "enhancement": [],
+    ],
     "stats": {
-      "command": 0,
-      "charm": 0,
-      "politics": 0
-    }
-  },
-  "memoryImprintFormation": {
-    "north": false,
-    "south": false,
-    "east": false,
-    "west": false
-  },
-  "memoryImprint": [
-    {
-      "rank": "d",
-      "status": {
-        "type": "",
-        "increase": 0
-      }
+        "base": {
+            "cp": 0,
+            "atk": 0,
+            "hp": 0,
+            "spd": 0,
+            "def": 0,
+            "chc": 0,
+            "chd": 0,
+            "eff": 0,
+            "efr": 0,
+            "dac": 0
+        },
+        "max": {
+            "cp": 0,
+            "atk": 0,
+            "hp": 0,
+            "spd": 0,
+            "def": 0,
+            "chc": 0,
+            "chd": 0,
+            "eff": 0,
+            "efr": 0,
+            "dac": 5
+        },
+        "max6": {
+            "chc": 15,
+            "chd": 150,
+            "eff": 0,
+            "dac": 5,
+            "hp": 5850,
+            "cp": 15038,
+            "spd": 102,
+            "atk": 816,
+            "def": 620,
+            "efr": 0
+        },
+        "max5": {
+            "chc": 15,
+            "chd": 150,
+            "eff": 0,
+            "dac": 5,
+            "hp": 4653,
+            "cp": 12050,
+            "spd": 102,
+            "atk": 655,
+            "def": 500,
+            "efr": 0
+        }
     },
-    {
-      "rank": "c",
-      "status": {
-        "type": "",
-        "increase": 0
-      }
+    "skills": [
+        {
+            "isPassive": false,
+            "soulBurn": 0,
+            "selfSkillBarValue": 15,
+            "soulBurnEffect": "",
+            "awakenUpgrade": false,
+            "cooldown": 0,
+            "name": "Knockout",
+            "soulAcquire": 1,
+            "description": "Attacks with a flurry of strikes, with a 35% chance to decrease Defense for 2 turns. If the caster is granted Vigor, also burns target for 2 turns. Damage dealt increases proportional to the caster's max Health.",
+            "enhancement": [
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5 Fighting Spirit acquired",
+                    "resources": [
+                        {
+                            "item": "slime-jelly",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 22000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "slime-jelly",
+                            "qty": 4
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "slime-jelly",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 45000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "dragons-wrath",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
+                        }
+                    ]
+                }
+            ],
+            "buffs": [],
+            "debuffs": [
+                "stic_def_dn",
+                "stic_blaze"
+            ]
+        },
+        {
+            "isPassive": false,
+            "soulBurn": 20,
+            "selfSkillBarValue": 0,
+            "soulBurnEffect": "Grants an extra turn.",
+            "awakenUpgrade": false,
+            "cooldown": 3,
+            "name": "Celestial Kick",
+            "soulAcquire": 2,
+            "description": "Attacks the enemy with a kick, increasing Speed of the caster for 2 turns, with a 75% chance to decrease Defense of the target for 2 turns. Gains 40 Fighting Spirit when an enemy is defeated. If caster is granted Vigor, ignores Effect Resistance. Damage dealt increases proportional to the caster's max Health.",
+            "enhancement": [
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "slime-jelly",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 19000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "slime-jelly",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 45000
+                        }
+                    ]
+                },
+                {
+                    "description": "+15% damage dealt",
+                    "resources": [
+                        {
+                            "item": "dragons-wrath",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 130000
+                        }
+                    ]
+                }
+            ],
+            "buffs": [],
+            "debuffs": []
+        },
+        {
+            "isPassive": false,
+            "soulBurn": 0,
+            "selfSkillBarValue": -100,
+            "soulBurnEffect": "",
+            "awakenUpgrade": true,
+            "cooldown": 6,
+            "name": "Phoenix Flurry",
+            "soulAcquire": 3,
+            "description": "Delivers a powerful blow after a flurry of strikes, stunning for 1 turn and decreasing Attack for 2 turns, before granting Vigor to the caster for 4 turns. Damage dealt increases proportional to the caster's max Health. Caster begins the first battle with 50 Fighting Spirit, and gains 5 Fighting Spirit when attacked.",
+            "enhancement": [
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "-1 turn cooldown",
+                    "resources": [
+                        {
+                            "item": "slime-jelly",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 22000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "slime-jelly",
+                            "qty": 4
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "slime-jelly",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 45000
+                        }
+                    ]
+                },
+                {
+                    "description": "+15% damage dealt",
+                    "resources": [
+                        {
+                            "item": "dragons-wrath",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
+                        }
+                    ]
+                }
+            ],
+            "buffs": [],
+            "debuffs": []
+        }
+    ],
+    "specialtySkill": {
+        "name": "Victory Is Ours",
+        "description": "Exuding confidence, no one can defeat him in this battle.",
+        "dispatch": [],
+        "enhancement": [],
+        "stats": {
+            "command": 0,
+            "charm": 0,
+            "politics": 0
+        }
     },
-    {
-      "rank": "b",
-      "status": {
-        "type": "",
-        "increase": 0
-      }
+    "memoryImprintFormation": {
+        "north": false,
+        "south": false,
+        "east": false,
+        "west": false
     },
-    {
-      "rank": "a",
-      "status": {
-        "type": "",
-        "increase": 0
-      }
-    },
-    {
-      "rank": "s",
-      "status": {
-        "type": "",
-        "increase": 0
-      }
-    },
-    {
-      "rank": "ss",
-      "status": {
-        "type": "",
-        "increase": 0
-      }
-    },
-    {
-      "rank": "sss",
-      "status": {
-        "type": "",
-        "increase": 0
-      }
-    }
-  ],
-  "awakening": [
-    {
-      "rank": 1,
-      "skillUpgrade": false,
-      "statsIncrease": [
+    "memoryImprint": [
         {
-          "": 0
+            "rank": "d",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
         },
         {
-          "atk": 20
+            "rank": "c",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
         },
         {
-          "hp": 60
+            "rank": "b",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
+        },
+        {
+            "rank": "a",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
+        },
+        {
+            "rank": "s",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
+        },
+        {
+            "rank": "ss",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
+        },
+        {
+            "rank": "sss",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
         }
-      ],
-      "resources": [
+    ],
+    "awakening": [
         {
-          "item": "fire-rune",
-          "qty": 10
+            "rank": 1,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "": 0
+                },
+                {
+                    "atk": 20
+                },
+                {
+                    "hp": 60
+                }
+            ],
+            "resources": [
+                {
+                    "item": "flame-rune",
+                    "qty": 10
+                }
+            ]
+        },
+        {
+            "rank": 2,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "": 0
+                },
+                {
+                    "atk": 20
+                },
+                {
+                    "hp": 60
+                }
+            ],
+            "resources": [
+                {
+                    "item": "flame-rune",
+                    "qty": 15
+                },
+                {
+                    "item": "greater-flame-rune",
+                    "qty": 2
+                }
+            ]
+        },
+        {
+            "rank": 3,
+            "skillUpgrade": true,
+            "statsIncrease": [
+                {
+                    "atk": 20
+                },
+                {
+                    "hp": 60
+                }
+            ],
+            "resources": [
+                {
+                    "item": "flame-rune",
+                    "qty": 20
+                },
+                {
+                    "item": "greater-flame-rune",
+                    "qty": 10
+                }
+            ]
+        },
+        {
+            "rank": 4,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "": 0
+                },
+                {
+                    "atk": 30
+                },
+                {
+                    "hp": 80
+                }
+            ],
+            "resources": [
+                {
+                    "item": "greater-flame-rune",
+                    "qty": 10
+                },
+                {
+                    "item": "epic-flame-rune",
+                    "qty": 2
+                }
+            ]
+        },
+        {
+            "rank": 5,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "": 0
+                },
+                {
+                    "atk": 30
+                },
+                {
+                    "hp": 80
+                }
+            ],
+            "resources": [
+                {
+                    "item": "epic-flame-rune",
+                    "qty": 6
+                },
+                {
+                    "item": "cursed-ashes",
+                    "qty": 15
+                }
+            ]
+        },
+        {
+            "rank": 6,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "": 0
+                },
+                {
+                    "atk": 30
+                },
+                {
+                    "hp": 80
+                }
+            ],
+            "resources": [
+                {
+                    "item": "epic-flame-rune",
+                    "qty": 10
+                },
+                {
+                    "item": "dragons-wrath",
+                    "qty": 10
+                }
+            ]
         }
-      ]
-    },
-    {
-      "rank": 2,
-      "skillUpgrade": false,
-      "statsIncrease": [
-        {
-          "": 0
-        },
-        {
-          "atk": 20
-        },
-        {
-          "hp": 60
-        }
-      ],
-      "resources": [
-        {
-          "item": "fire-rune",
-          "qty": 15
-        },
-        {
-          "item": "greater-fire-rune",
-          "qty": 2
-        }
-      ]
-    },
-    {
-      "rank": 3,
-      "skillUpgrade": true,
-      "statsIncrease": [
-        {
-          "atk": 20
-        },
-        {
-          "hp": 60
-        }
-      ],
-      "resources": [
-        {
-          "item": "fire-rune",
-          "qty": 20
-        },
-        {
-          "item": "greater-fire-rune",
-          "qty": 10
-        }
-      ]
-    },
-    {
-      "rank": 4,
-      "skillUpgrade": false,
-      "statsIncrease": [
-        {
-          "": 0
-        },
-        {
-          "atk": 30
-        },
-        {
-          "hp": 80
-        }
-      ],
-      "resources": [
-        {
-          "item": "greater-fire-rune",
-          "qty": 10
-        },
-        {
-          "item": "epic-fire-rune",
-          "qty": 2
-        }
-      ]
-    },
-    {
-      "rank": 5,
-      "skillUpgrade": false,
-      "statsIncrease": [
-        {
-          "": 0
-        },
-        {
-          "atk": 30
-        },
-        {
-          "hp": 80
-        }
-      ],
-      "resources": [
-        {
-          "item": "epic-fire-rune",
-          "qty": 6
-        },
-        {
-          "item": "cursed-ashes",
-          "qty": 15
-        }
-      ]
-    },
-    {
-      "rank": 6,
-      "skillUpgrade": false,
-      "statsIncrease": [
-        {
-          "": 0
-        },
-        {
-          "atk": 30
-        },
-        {
-          "hp": 80
-        }
-      ],
-      "resources": [
-        {
-          "item": "epic-fire-rune",
-          "qty": 10
-        },
-        {
-          "item": "dragons-wrath",
-          "qty": 10
-        }
-      ]
-    }
-  ]
+    ]
 }

--- a/src/hero/krau.json
+++ b/src/hero/krau.json
@@ -96,11 +96,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "4000"
+                            "qty": 4000
                         }
                     ]
                 },
@@ -109,11 +109,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": "8000"
+                            "qty": 8000
                         }
                     ]
                 },
@@ -122,15 +122,15 @@
                     "resources": [
                         {
                             "item": "strange-jelly",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "molagora",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "22000"
+                            "qty": 22000
                         }
                     ]
                 },
@@ -139,15 +139,15 @@
                     "resources": [
                         {
                             "item": "strange-jelly",
-                            "qty": "4"
+                            "qty": 4
                         },
                         {
                             "item": "molagora",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "gold",
-                            "qty": "40000"
+                            "qty": 40000
                         }
                     ]
                 },
@@ -156,15 +156,15 @@
                     "resources": [
                         {
                             "item": "strange-jelly",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "molagorago",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "45000"
+                            "qty": 45000
                         }
                     ]
                 },
@@ -173,21 +173,23 @@
                     "resources": [
                         {
                             "item": "ancient-creature-nucleus",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "molagorago",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "120000"
+                            "qty": 120000
                         }
                     ]
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_provoke"]
+            "debuffs": [
+                "stic_provoke"
+            ]
         },
         {
             "isPassive": false,
@@ -205,11 +207,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "4000"
+                            "qty": 4000
                         }
                     ]
                 },
@@ -218,11 +220,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": "8000"
+                            "qty": 8000
                         }
                     ]
                 },
@@ -231,11 +233,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "12000"
+                            "qty": 12000
                         }
                     ]
                 },
@@ -244,15 +246,15 @@
                     "resources": [
                         {
                             "item": "strange-jelly",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "molagora",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "27000"
+                            "qty": 27000
                         }
                     ]
                 },
@@ -261,15 +263,15 @@
                     "resources": [
                         {
                             "item": "strange-jelly",
-                            "qty": "4"
+                            "qty": 4
                         },
                         {
                             "item": "molagora",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "gold",
-                            "qty": "40000"
+                            "qty": 40000
                         }
                     ]
                 },
@@ -278,15 +280,15 @@
                     "resources": [
                         {
                             "item": "strange-jelly",
-                            "qty": "7"
+                            "qty": 7
                         },
                         {
                             "item": "molagorago",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "55000"
+                            "qty": 55000
                         }
                     ]
                 },
@@ -295,20 +297,22 @@
                     "resources": [
                         {
                             "item": "ancient-creature-nucleus",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "molagorago",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "150000"
+                            "qty": 150000
                         }
                     ]
                 }
             ],
-            "buffs": ["stic_def_up"],
+            "buffs": [
+                "stic_def_up"
+            ],
             "debuffs": []
         },
         {
@@ -327,15 +331,15 @@
                     "resources": [
                         {
                             "item": "strange-jelly",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "molagora",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "37000"
+                            "qty": 37000
                         }
                     ]
                 },
@@ -344,20 +348,22 @@
                     "resources": [
                         {
                             "item": "ancient-creature-nucleus",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "molagorago",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": "100000"
+                            "qty": 100000
                         }
                     ]
                 }
             ],
-            "buffs": ["stic_protect"],
+            "buffs": [
+                "stic_protect"
+            ],
             "debuffs": []
         }
     ],

--- a/src/hero/ludwig.json
+++ b/src/hero/ludwig.json
@@ -77,26 +77,61 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% effect chance",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "twisted-fang",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "twisted-fang",
+                            "qty": 7
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
                         }
                     ]
                 },
@@ -104,12 +139,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "blazing-soul",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -130,26 +169,61 @@
             "enhancement": [
                 {
                     "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% effect chance",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "twisted-fang",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "twisted-fang",
+                            "qty": 7
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
                         }
                     ]
                 },
@@ -157,12 +231,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "blazing-soul",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -183,26 +261,61 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "twisted-fang",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "twisted-fang",
+                            "qty": 7
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
                         }
                     ]
                 },
@@ -210,12 +323,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "blazing-soul",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -309,7 +426,7 @@
             ],
             "resources": [
                 {
-                    "item": "earth-rune",
+                    "item": "life-rune",
                     "qty": 10
                 }
             ]
@@ -330,11 +447,11 @@
             ],
             "resources": [
                 {
-                    "item": "earth-rune",
+                    "item": "life-rune",
                     "qty": 15
                 },
                 {
-                    "item": "greater-earth-rune",
+                    "item": "greater-life-rune",
                     "qty": 2
                 }
             ]
@@ -352,11 +469,11 @@
             ],
             "resources": [
                 {
-                    "item": "earth-rune",
+                    "item": "life-rune",
                     "qty": 20
                 },
                 {
-                    "item": "greater-earth-rune",
+                    "item": "greater-life-rune",
                     "qty": 10
                 }
             ]
@@ -377,11 +494,11 @@
             ],
             "resources": [
                 {
-                    "item": "greater-earth-rune",
+                    "item": "greater-life-rune",
                     "qty": 10
                 },
                 {
-                    "item": "epic-earth-rune",
+                    "item": "epic-life-rune",
                     "qty": 2
                 }
             ]
@@ -402,7 +519,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-earth-rune",
+                    "item": "epic-life-rune",
                     "qty": 6
                 },
                 {
@@ -427,7 +544,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-earth-rune",
+                    "item": "epic-life-rune",
                     "qty": 10
                 },
                 {

--- a/src/hero/luna.json
+++ b/src/hero/luna.json
@@ -77,26 +77,44 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 1
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "mysterious-flash",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
                         }
                     ]
                 },
@@ -104,12 +122,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "mysterious-flash",
+                            "qty": 7
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "reingar-student-id",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -130,26 +169,61 @@
             "enhancement": [
                 {
                     "description": "+1% all stats",
-                    "resources": []
-                },
-                {
-                    "description": "+2% all stats",
-                    "resources": []
-                },
-                {
-                    "description": "+2% all stats",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+2% all stats",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+2% all stats",
+                    "resources": [
+                        {
+                            "item": "mysterious-flash",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
+                        }
+                    ]
+                },
+                {
+                    "description": "+2% all stats",
+                    "resources": [
+                        {
+                            "item": "mysterious-flash",
+                            "qty": 7
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
                         }
                     ]
                 },
@@ -157,12 +231,16 @@
                     "description": "+3% all stats",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "reingar-student-id",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -183,26 +261,27 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+10% effect chance",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
@@ -210,12 +289,50 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "mysterious-flash",
+                            "qty": 5
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% effect chance",
+                    "resources": [
+                        {
+                            "item": "mysterious-flash",
+                            "qty": 7
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "reingar-student-id",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -309,7 +426,7 @@
             ],
             "resources": [
                 {
-                    "item": "ice-rune",
+                    "item": "frost-rune",
                     "qty": 10
                 }
             ]
@@ -330,11 +447,11 @@
             ],
             "resources": [
                 {
-                    "item": "ice-rune",
+                    "item": "frost-rune",
                     "qty": 15
                 },
                 {
-                    "item": "greater-ice-rune",
+                    "item": "greater-frost-rune",
                     "qty": 2
                 }
             ]
@@ -352,11 +469,11 @@
             ],
             "resources": [
                 {
-                    "item": "ice-rune",
+                    "item": "frost-rune",
                     "qty": 20
                 },
                 {
-                    "item": "greater-ice-rune",
+                    "item": "greater-frost-rune",
                     "qty": 10
                 }
             ]
@@ -377,11 +494,11 @@
             ],
             "resources": [
                 {
-                    "item": "greater-ice-rune",
+                    "item": "greater-frost-rune",
                     "qty": 10
                 },
                 {
-                    "item": "epic-ice-rune",
+                    "item": "epic-frost-rune",
                     "qty": 2
                 }
             ]
@@ -402,7 +519,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-ice-rune",
+                    "item": "epic-frost-rune",
                     "qty": 6
                 },
                 {
@@ -427,7 +544,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-ice-rune",
+                    "item": "epic-frost-rune",
                     "qty": 10
                 },
                 {

--- a/src/hero/maid-chloe.json
+++ b/src/hero/maid-chloe.json
@@ -92,11 +92,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "4000"
+                            "qty": 4000
                         }
                     ]
                 },
@@ -105,11 +105,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": "8000"
+                            "qty": 8000
                         }
                     ]
                 },
@@ -118,11 +118,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "12000"
+                            "qty": 12000
                         }
                     ]
                 },
@@ -131,15 +131,15 @@
                     "resources": [
                         {
                             "item": "flame-of-soul",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "molagora",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "27000"
+                            "qty": 27000
                         }
                     ]
                 },
@@ -148,15 +148,15 @@
                     "resources": [
                         {
                             "item": "flame-of-soul",
-                            "qty": "4"
+                            "qty": 4
                         },
                         {
                             "item": "molagora",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "gold",
-                            "qty": "4000"
+                            "qty": 40000
                         }
                     ]
                 },
@@ -165,15 +165,15 @@
                     "resources": [
                         {
                             "item": "flame-of-soul",
-                            "qty": "7"
+                            "qty": 7
                         },
                         {
                             "item": "molagorago",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "55000"
+                            "qty": 55000
                         }
                     ]
                 },
@@ -182,21 +182,23 @@
                     "resources": [
                         {
                             "item": "demon-blood-gem",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "molagorago",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "150000"
+                            "qty": 150000
                         }
                     ]
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_stun"]
+            "debuffs": [
+                "stic_stun"
+            ]
         },
         {
             "isPassive": true,
@@ -214,11 +216,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "4000"
+                            "qty": 4000
                         }
                     ]
                 },
@@ -227,11 +229,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": "8000"
+                            "qty": 8000
                         }
                     ]
                 },
@@ -240,11 +242,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "12000"
+                            "qty": 12000
                         }
                     ]
                 },
@@ -253,15 +255,15 @@
                     "resources": [
                         {
                             "item": "flame-of-soul",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "molagora",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "27000"
+                            "qty": 27000
                         }
                     ]
                 },
@@ -270,15 +272,15 @@
                     "resources": [
                         {
                             "item": "flame-of-soul",
-                            "qty": "4"
+                            "qty": 4
                         },
                         {
                             "item": "molagora",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "gold",
-                            "qty": "40000"
+                            "qty": 40000
                         }
                     ]
                 },
@@ -287,15 +289,15 @@
                     "resources": [
                         {
                             "item": "flame-of-soul",
-                            "qty": "7"
+                            "qty": 7
                         },
                         {
                             "item": "molagorago",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "55000"
+                            "qty": 55000
                         }
                     ]
                 },
@@ -304,15 +306,15 @@
                     "resources": [
                         {
                             "item": "demon-blood-gem",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "molagorago",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "150000"
+                            "qty": 150000
                         }
                     ]
                 }
@@ -335,21 +337,24 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": "8"
+                            "item": "demon-blood-gem",
+                            "qty": 8
                         },
                         {
                             "item": "molagorago",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": "80000"
+                            "qty": 80000
                         }
                     ]
                 }
             ],
-            "buffs": ["stic_bless", "stic_att_up"],
+            "buffs": [
+                "stic_bless",
+                "stic_att_up"
+            ],
             "debuffs": []
         }
     ],
@@ -439,7 +444,7 @@
             "resources": [
                 {
                     "item": "light-rune",
-                    "qty": "10"
+                    "qty": 10
                 }
             ]
         },
@@ -460,11 +465,11 @@
             "resources": [
                 {
                     "item": "light-rune",
-                    "qty": "15"
+                    "qty": 15
                 },
                 {
                     "item": "greater-light-rune",
-                    "qty": "2"
+                    "qty": 2
                 }
             ]
         },
@@ -482,11 +487,11 @@
             "resources": [
                 {
                     "item": "light-rune",
-                    "qty": "20"
+                    "qty": 20
                 },
                 {
                     "item": "greater-light-rune",
-                    "qty": "10"
+                    "qty": 10
                 }
             ]
         },
@@ -507,11 +512,11 @@
             "resources": [
                 {
                     "item": "greater-light-rune",
-                    "qty": "10"
+                    "qty": 10
                 },
                 {
                     "item": "epic-light-rune",
-                    "qty": "2"
+                    "qty": 2
                 }
             ]
         },
@@ -532,11 +537,11 @@
             "resources": [
                 {
                     "item": "epic-light-rune",
-                    "qty": "6"
+                    "qty": 6
                 },
                 {
                     "item": "eternal-forest-dust",
-                    "qty": "15"
+                    "qty": 15
                 }
             ]
         },
@@ -557,11 +562,11 @@
             "resources": [
                 {
                     "item": "epic-light-rune",
-                    "qty": "10"
+                    "qty": 10
                 },
                 {
                     "item": "demon-blood-gem",
-                    "qty": "10"
+                    "qty": 10
                 }
             ]
         }

--- a/src/hero/martial-artist-ken.json
+++ b/src/hero/martial-artist-ken.json
@@ -79,7 +79,7 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
@@ -92,11 +92,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": "8000"
+                            "qty": 8000
                         }
                     ]
                 },
@@ -105,15 +105,15 @@
                     "resources": [
                         {
                             "item": "twisted-fang",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "molagora",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "22000"
+                            "qty": 22000
                         }
                     ]
                 },
@@ -122,15 +122,15 @@
                     "resources": [
                         {
                             "item": "twisted-fang",
-                            "qty": "4"
+                            "qty": 4
                         },
                         {
                             "item": "molagora",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "gold",
-                            "qty": "40000"
+                            "qty": 40000
                         }
                     ]
                 },
@@ -139,15 +139,15 @@
                     "resources": [
                         {
                             "item": "twisted-fang",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "molagorago",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "45000"
+                            "qty": 45000
                         }
                     ]
                 },
@@ -156,21 +156,23 @@
                     "resources": [
                         {
                             "item": "blazing-soul",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "molagorago",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "120000"
+                            "qty": 120000
                         }
                     ]
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_att_dn"]
+            "debuffs": [
+                "stic_att_dn"
+            ]
         },
         {
             "isPassive": true,
@@ -187,15 +189,15 @@
                     "resources": [
                         {
                             "item": "twisted-fang",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "molagora",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "19000"
+                            "qty": 19000
                         }
                     ]
                 },
@@ -204,15 +206,15 @@
                     "resources": [
                         {
                             "item": "twisted-fang",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
-                            "item": "molagorago",
-                            "qty": "2"
+                            "item": "molagora",
+                            "qty": 5
                         },
                         {
                             "item": "gold",
-                            "qty": "65000"
+                            "qty": 45000
                         }
                     ]
                 },
@@ -221,15 +223,15 @@
                     "resources": [
                         {
                             "item": "blazing-soul",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
-                            "item": "molagoragora",
-                            "qty": "1"
+                            "item": "molagorago",
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": "190000"
+                            "qty": 130000
                         }
                     ]
                 }
@@ -252,11 +254,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "4000"
+                            "qty": 4000
                         }
                     ]
                 },
@@ -265,11 +267,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": "8000"
+                            "qty": 8000
                         }
                     ]
                 },
@@ -278,15 +280,15 @@
                     "resources": [
                         {
                             "item": "twisted-fang",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "molagora",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "22000"
+                            "qty": 22000
                         }
                     ]
                 },
@@ -295,15 +297,15 @@
                     "resources": [
                         {
                             "item": "twisted-fang",
-                            "qty": "4"
+                            "qty": 4
                         },
                         {
                             "item": "molagora",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "gold",
-                            "qty": "40000"
+                            "qty": 40000
                         }
                     ]
                 },
@@ -312,15 +314,15 @@
                     "resources": [
                         {
                             "item": "twisted-fang",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "molagorago",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "45000"
+                            "qty": 45000
                         }
                     ]
                 },
@@ -329,28 +331,36 @@
                     "resources": [
                         {
                             "item": "blazing-soul",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "molagorago",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "120000"
+                            "qty": 120000
                         }
                     ]
                 }
             ],
-            "buffs": ["stic_att_up"],
-            "debuffs": ["stic_def_dn"]
+            "buffs": [
+                "stic_att_up"
+            ],
+            "debuffs": [
+                "stic_def_dn"
+            ]
         }
     ],
     "specialtySkill": {
         "name": "Finding the Strongest",
         "description": "His desire to fight the strongest made him follow the path of Asura.",
-        "dispatch": ["[Chase] type mission"],
-        "enhancement": ["Reward bonus +6%"],
+        "dispatch": [
+            "[Chase] type mission"
+        ],
+        "enhancement": [
+            "Reward bonus +6%"
+        ],
         "stats": {
             "command": 28,
             "charm": 29,
@@ -432,7 +442,7 @@
             "resources": [
                 {
                     "item": "dark-rune",
-                    "qty": "10"
+                    "qty": 10
                 }
             ]
         },
@@ -453,11 +463,11 @@
             "resources": [
                 {
                     "item": "dark-rune",
-                    "qty": "15"
+                    "qty": 15
                 },
                 {
                     "item": "greater-dark-rune",
-                    "qty": "2"
+                    "qty": 2
                 }
             ]
         },
@@ -475,11 +485,11 @@
             "resources": [
                 {
                     "item": "dark-rune",
-                    "qty": "20"
+                    "qty": 20
                 },
                 {
                     "item": "greater-dark-rune",
-                    "qty": "10"
+                    "qty": 10
                 }
             ]
         },
@@ -500,11 +510,11 @@
             "resources": [
                 {
                     "item": "greater-dark-rune",
-                    "qty": "10"
+                    "qty": 10
                 },
                 {
                     "item": "epic-dark-rune",
-                    "qty": "2"
+                    "qty": 2
                 }
             ]
         },
@@ -525,11 +535,11 @@
             "resources": [
                 {
                     "item": "epic-dark-rune",
-                    "qty": "6"
+                    "qty": 6
                 },
                 {
                     "item": "ultra-fang",
-                    "qty": "15"
+                    "qty": 15
                 }
             ]
         },
@@ -550,11 +560,11 @@
             "resources": [
                 {
                     "item": "epic-dark-rune",
-                    "qty": "10"
+                    "qty": 10
                 },
                 {
                     "item": "blazing-soul",
-                    "qty": "10"
+                    "qty": 10
                 }
             ]
         }

--- a/src/hero/ravi.json
+++ b/src/hero/ravi.json
@@ -340,14 +340,20 @@
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_stun"]
+            "debuffs": [
+                "stic_stun"
+            ]
         }
     ],
     "specialtySkill": {
         "name": "Blood Burst",
         "description": "She vanquishes all enemies according to Acolyte Tenebria's will.",
-        "dispatch": ["[Strong Leader] Attribute"],
-        "enhancement": ["Reward Bonus +10%"],
+        "dispatch": [
+            "[Strong Leader] Attribute"
+        ],
+        "enhancement": [
+            "Reward Bonus +10%"
+        ],
         "stats": {
             "command": 56,
             "charm": 43,

--- a/src/hero/ruele-of-light.json
+++ b/src/hero/ruele-of-light.json
@@ -111,11 +111,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": 3
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": 12000
+                            "qty": 8000
                         }
                     ]
                 },
@@ -128,11 +128,11 @@
                         },
                         {
                             "item": "molagora",
-                            "qty": 4
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": 26000
+                            "qty": 22000
                         }
                     ]
                 },
@@ -144,12 +144,12 @@
                             "qty": 4
                         },
                         {
-                            "item": "molagorago",
-                            "qty": 1
+                            "item": "molagora",
+                            "qty": 5
                         },
                         {
                             "item": "gold",
-                            "qty": 26000
+                            "qty": 40000
                         }
                     ]
                 },
@@ -162,11 +162,11 @@
                         },
                         {
                             "item": "molagorago",
-                            "qty": 2
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": 65000
+                            "qty": 45000
                         }
                     ]
                 },
@@ -178,12 +178,12 @@
                             "qty": 2
                         },
                         {
-                            "item": "molagoragora",
-                            "qty": 1
+                            "item": "molagorago",
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": 160000
+                            "qty": 120000
                         }
                     ]
                 }
@@ -249,12 +249,12 @@
                             "qty": 3
                         },
                         {
-                            "item": "molagorago",
-                            "qty": 1
+                            "item": "molagora",
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": 35000
+                            "qty": 27000
                         }
                     ]
                 },
@@ -266,12 +266,12 @@
                             "qty": 4
                         },
                         {
-                            "item": "molagorago",
-                            "qty": 1
+                            "item": "molagora",
+                            "qty": 5
                         },
                         {
                             "item": "gold",
-                            "qty": 60000
+                            "qty": 40000
                         }
                     ]
                 },
@@ -284,11 +284,11 @@
                         },
                         {
                             "item": "molagorago",
-                            "qty": 2
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": 75000
+                            "qty": 55000
                         }
                     ]
                 },
@@ -300,17 +300,19 @@
                             "qty": 3
                         },
                         {
-                            "item": "molagoragora",
-                            "qty": 1
+                            "item": "molagorago",
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": 190000
+                            "qty": 150000
                         }
                     ]
                 }
             ],
-            "buffs": ["stic_protect"],
+            "buffs": [
+                "stic_protect"
+            ],
             "debuffs": []
         },
         {
@@ -337,7 +339,7 @@
                         },
                         {
                             "item": "gold",
-                            "qty": 19000
+                            "qty": 37000
                         }
                     ]
                 },
@@ -349,25 +351,31 @@
                             "qty": 2
                         },
                         {
-                            "item": "molagoragora",
-                            "qty": 1
+                            "item": "molagorago",
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": 160000
+                            "qty": 100000
                         }
                     ]
                 }
             ],
-            "buffs": ["stic_invincible"],
+            "buffs": [
+                "stic_invincible"
+            ],
             "debuffs": []
         }
     ],
     "specialtySkill": {
         "name": "Saint of Light",
         "description": "In her presence, even evil loses its darkness.",
-        "dispatch": ["[Fear] type mission"],
-        "enhancement": ["Reward bonus +10%"],
+        "dispatch": [
+            "[Fear] type mission"
+        ],
+        "enhancement": [
+            "Reward bonus +10%"
+        ],
         "stats": {
             "command": 45,
             "charm": 79,

--- a/src/hero/sez.json
+++ b/src/hero/sez.json
@@ -89,35 +89,31 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 4000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": 8000
-                        },
                         {
                             "item": "molagora",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": 37000
-                        },
                         {
                             "item": "sharp-spearhead",
                             "qty": 5
@@ -125,16 +121,16 @@
                         {
                             "item": "molagora",
                             "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": 55000
-                        },
                         {
                             "item": "sharp-spearhead",
                             "qty": 7
@@ -142,6 +138,10 @@
                         {
                             "item": "molagorago",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
                         }
                     ]
                 },
@@ -149,22 +149,24 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 120000
-                        },
-                        {
                             "item": "black-curse-powder",
                             "qty": 2
                         },
                         {
                             "item": "molagorago",
                             "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_heal_impossible"]
+            "debuffs": [
+                "stic_heal_impossible"
+            ]
         },
         {
             "isPassive": true,
@@ -180,35 +182,31 @@
                     "description": "+5% damage dealt by additional skill",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 4000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt by additional skill",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": 8000
-                        },
                         {
                             "item": "molagora",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt by additional skill",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": 37000
-                        },
                         {
                             "item": "sharp-spearhead",
                             "qty": 5
@@ -216,6 +214,10 @@
                         {
                             "item": "molagora",
                             "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
                         }
                     ]
                 },
@@ -223,16 +225,16 @@
                     "description": "+5% damage dealt by additional skill",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 55000
-                        },
-                        {
                             "item": "sharp-spearhead",
                             "qty": 7
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
                         }
                     ]
                 },
@@ -240,22 +242,24 @@
                     "description": "+10% damage dealt by additional skill",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 120000
-                        },
-                        {
                             "item": "black-curse-powder",
                             "qty": 2
                         },
                         {
                             "item": "molagorago",
                             "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_heal_impossible"]
+            "debuffs": [
+                "stic_heal_impossible"
+            ]
         },
         {
             "isPassive": false,
@@ -271,12 +275,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 4000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
                         }
                     ]
                 },
@@ -284,12 +288,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 8000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
@@ -297,16 +301,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 37000
-                        },
-                        {
                             "item": "sharp-spearhead",
                             "qty": 5
                         },
                         {
                             "item": "molagora",
                             "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
                         }
                     ]
                 },
@@ -314,16 +318,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 55000
-                        },
-                        {
                             "item": "sharp-spearhead",
                             "qty": 7
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
                         }
                     ]
                 },
@@ -331,16 +335,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 120000
-                        },
-                        {
                             "item": "black-curse-powder",
                             "qty": 2
                         },
                         {
                             "item": "molagorago",
                             "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -352,8 +356,12 @@
     "specialtySkill": {
         "name": "Ridiculous Answer",
         "description": "Makes stupid comments and is always wasting time no matter how dire the situation.",
-        "dispatch": ["[All missions] type mission"],
-        "enhancement": ["Time required -5%"],
+        "dispatch": [
+            "[All missions] type mission"
+        ],
+        "enhancement": [
+            "Time required -5%"
+        ],
         "stats": {
             "command": 15,
             "charm": 67,
@@ -526,7 +534,7 @@
                 },
                 {
                     "item": "erikion-carapace",
-                    "qty": 12
+                    "qty": 15
                 }
             ]
         },
@@ -551,7 +559,7 @@
                 },
                 {
                     "item": "black-curse-powder",
-                    "qty": 8
+                    "qty": 10
                 }
             ]
         }

--- a/src/hero/sigret.json
+++ b/src/hero/sigret.json
@@ -77,26 +77,61 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% effect chance",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "shiny-enchantment",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% effect chance",
+                    "resources": [
+                        {
+                            "item": "shiny-enchantment",
+                            "qty": 7
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
                         }
                     ]
                 },
@@ -104,12 +139,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "horn-of-desire",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -130,26 +169,61 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% effect chance",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "shiny-enchantment",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "shiny-enchantment",
+                            "qty": 7
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
                         }
                     ]
                 },
@@ -157,12 +231,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "horn-of-desire",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -183,26 +261,44 @@
             "enhancement": [
                 {
                     "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
-                },
-                {
-                    "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "shiny-enchantment",
+                            "qty": 5
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
                         }
                     ]
                 },
@@ -210,12 +306,33 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "shiny-enchantment",
+                            "qty": 7
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
+                        }
+                    ]
+                },
+                {
+                    "description": "+15% damage dealt",
+                    "resources": [
+                        {
+                            "item": "horn-of-desire",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -309,7 +426,7 @@
             ],
             "resources": [
                 {
-                    "item": "ice-rune",
+                    "item": "frost-rune",
                     "qty": 10
                 }
             ]
@@ -330,11 +447,11 @@
             ],
             "resources": [
                 {
-                    "item": "ice-rune",
+                    "item": "frost-rune",
                     "qty": 15
                 },
                 {
-                    "item": "greater-ice-rune",
+                    "item": "greater-frost-rune",
                     "qty": 2
                 }
             ]
@@ -352,11 +469,11 @@
             ],
             "resources": [
                 {
-                    "item": "ice-rune",
+                    "item": "frost-rune",
                     "qty": 20
                 },
                 {
-                    "item": "greater-ice-rune",
+                    "item": "greater-frost-rune",
                     "qty": 10
                 }
             ]
@@ -377,11 +494,11 @@
             ],
             "resources": [
                 {
-                    "item": "greater-ice-rune",
+                    "item": "greater-frost-rune",
                     "qty": 10
                 },
                 {
-                    "item": "epic-ice-rune",
+                    "item": "epic-frost-rune",
                     "qty": 2
                 }
             ]
@@ -402,7 +519,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-ice-rune",
+                    "item": "epic-frost-rune",
                     "qty": 6
                 },
                 {
@@ -427,7 +544,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-ice-rune",
+                    "item": "epic-frost-rune",
                     "qty": 10
                 },
                 {

--- a/src/hero/specter-tenebria.json
+++ b/src/hero/specter-tenebria.json
@@ -93,47 +93,103 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": [{ "item": "molagora", "qty": 1 }, { "item": "gold", "qty": 4000 }]
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% effect chance",
-                    "resources": [{ "item": "molagora", "qty": 2 }, { "item": "gold", "qty": 12000 }]
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        { "item": "ring-of-glory", "qty": 2 },
-                        { "item": "molagora", "qty": 3 },
-                        { "item": "gold", "qty": 22000 }
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 22000
+                        }
                     ]
                 },
                 {
                     "description": "+15% effect chance",
                     "resources": [
-                        { "item": "ring-of-glory", "qty": 4 },
-                        { "item": "molagora", "qty": 5 },
-                        { "item": "gold", "qty": 40000 }
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 4
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
+                        }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        { "item": "ring-of-glory", "qty": 5 },
-                        { "item": "molagorago", "qty": 1 },
-                        { "item": "gold", "qty": 45000 }
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 45000
+                        }
                     ]
                 },
                 {
                     "description": "+15% damage dealt",
                     "resources": [
-                        { "item": "fused-nerve", "qty": 2 },
-                        { "item": "molagorago", "qty": 3 },
-                        { "item": "gold", "qty": 120000 }
+                        {
+                            "item": "fused-nerve",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
+                        }
                     ]
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_dot"]
+            "debuffs": [
+                "stic_dot"
+            ]
         },
         {
             "isPassive": true,
@@ -149,25 +205,52 @@
                 {
                     "description": "-2% damage received",
                     "resources": [
-                        { "item": "ring-of-glory", "qty": 3 },
-                        { "item": "molagora", "qty": 1 },
-                        { "item": "gold", "qty": 19000 }
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 19000
+                        }
                     ]
                 },
                 {
                     "description": "-3% damage received",
                     "resources": [
-                        { "item": "ring-of-glory", "qty": 5 },
-                        { "item": "molagora", "qty": 5 },
-                        { "item": "gold", "qty": 45000 }
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 45000
+                        }
                     ]
                 },
                 {
                     "description": "-5% damage received",
                     "resources": [
-                        { "item": "fused-nerve", "qty": 3 },
-                        { "item": "molagorago", "qty": 2 },
-                        { "item": "gold", "qty": 130000 }
+                        {
+                            "item": "fused-nerve",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 130000
+                        }
                     ]
                 }
             ],
@@ -187,42 +270,96 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": [{ "item": "molagora", "qty": 1 }, { "item": "gold", "qty": 4000 }]
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
-                    "resources": [{ "item": "molagora", "qty": 2 }, { "item": "gold", "qty": 12000 }]
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
                     "resources": [
-                        { "item": "ring-of-glory", "qty": 2 },
-                        { "item": "molagora", "qty": 3 },
-                        { "item": "gold", "qty": 22000 }
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 22000
+                        }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        { "item": "ring-of-glory", "qty": 4 },
-                        { "item": "molagora", "qty": 5 },
-                        { "item": "gold", "qty": 40000 }
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 4
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
+                        }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        { "item": "ring-of-glory", "qty": 5 },
-                        { "item": "molagorago", "qty": 1 },
-                        { "item": "gold", "qty": 45000 }
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 45000
+                        }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        { "item": "fused-nerve", "qty": 2 },
-                        { "item": "molagorago", "qty": 3 },
-                        { "item": "gold", "qty": 120000 }
+                        {
+                            "item": "fused-nerve",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
+                        }
                     ]
                 }
             ],
@@ -233,8 +370,12 @@
     "specialtySkill": {
         "name": "Similar but Better",
         "description": "Sometimes fulfilling desires can result in great things.",
-        "dispatch": ["[Weakened] Attribute"],
-        "enhancement": ["Reward Bonus +10%"],
+        "dispatch": [
+            "[Weakened] Attribute"
+        ],
+        "enhancement": [
+            "Reward Bonus +10%"
+        ],
         "stats": {
             "command": 34,
             "charm": 84,

--- a/src/hero/tywin.json
+++ b/src/hero/tywin.json
@@ -89,12 +89,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 4000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
                         }
                     ]
                 },
@@ -102,12 +102,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 8000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
@@ -115,16 +115,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 26000
-                        },
-                        {
-                            "item": "path power loop",
+                            "item": "path-power-loop",
                             "qty": 2
                         },
                         {
                             "item": "molagora",
                             "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 22000
                         }
                     ]
                 },
@@ -132,16 +132,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 40000
-                        },
-                        {
-                            "item": "path power loop",
+                            "item": "path-power-loop",
                             "qty": 4
                         },
                         {
                             "item": "molagora",
                             "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
                         }
                     ]
                 },
@@ -149,16 +149,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 45000
-                        },
-                        {
-                            "item": "path power loop",
+                            "item": "path-power-loop",
                             "qty": 5
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 45000
                         }
                     ]
                 },
@@ -166,16 +166,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 120000
-                        },
-                        {
-                            "item": "nigthmare mask",
+                            "item": "nightmare-mask",
                             "qty": 2
                         },
                         {
-                            "item": "molagoragora",
-                            "qty": 1
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -197,16 +197,16 @@
                     "description": "Acquire +1 soul",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 37000
-                        },
-                        {
-                            "item": "path power loop",
+                            "item": "path-power-loop",
                             "qty": 5
                         },
                         {
                             "item": "molagora",
                             "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
                         }
                     ]
                 },
@@ -214,21 +214,24 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 100000
-                        },
-                        {
-                            "item": "nightmare mask",
+                            "item": "nightmare-mask",
                             "qty": 2
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
             ],
-            "buffs": ["stic_atk_up", "stic_chc_up"],
+            "buffs": [
+                "stic_atk_up",
+                "stic_chc_up"
+            ],
             "debuffs": []
         },
         {
@@ -245,12 +248,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 4000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
                         }
                     ]
                 },
@@ -258,12 +261,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 8000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
@@ -271,12 +274,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 12000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 12000
                         }
                     ]
                 },
@@ -284,16 +287,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 27000
-                        },
-                        {
-                            "item": "path power loop",
+                            "item": "path-power-loop",
                             "qty": 3
                         },
                         {
                             "item": "molagora",
                             "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 27000
                         }
                     ]
                 },
@@ -301,16 +304,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 40000
-                        },
-                        {
-                            "item": "path power loop",
+                            "item": "path-power-loop",
                             "qty": 4
                         },
                         {
                             "item": "molagora",
                             "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
                         }
                     ]
                 },
@@ -318,16 +321,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 55000
-                        },
-                        {
-                            "item": "path power loop",
+                            "item": "path-power-loop",
                             "qty": 7
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
                         }
                     ]
                 },
@@ -335,29 +338,37 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 150000
-                        },
-                        {
-                            "item": "nightmare mask",
+                            "item": "nightmare-mask",
                             "qty": 3
                         },
                         {
                             "item": "molagorago",
                             "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 150000
                         }
                     ]
                 }
             ],
-            "buffs": ["stic_def_up"],
-            "debuffs": ["stic_def_dn"]
+            "buffs": [
+                "stic_def_up"
+            ],
+            "debuffs": [
+                "stic_def_dn"
+            ]
         }
     ],
     "specialtySkill": {
         "name": "Commander",
         "description": "His incredible command ability boosts the efficiency of his troops.",
-        "dispatch": ["[War] type mission"],
-        "enhancement": ["Time requiered -6%"],
+        "dispatch": [
+            "[War] type mission"
+        ],
+        "enhancement": [
+            "Time requiered -6%"
+        ],
         "stats": {
             "command": 98,
             "charm": 75,

--- a/src/hero/vildred.json
+++ b/src/hero/vildred.json
@@ -77,26 +77,44 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 1
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "twisted-fang",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
                         }
                     ]
                 },
@@ -104,12 +122,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "twisted-fang",
+                            "qty": 7
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "blazing-soul",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -130,26 +169,61 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt by additional skill",
-                    "resources": []
-                },
-                {
-                    "description": "+5% damage dealt by additional skill",
-                    "resources": []
-                },
-                {
-                    "description": "+5% damage dealt by additional skill",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt by additional skill",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt by additional skill",
+                    "resources": [
+                        {
+                            "item": "twisted-fang",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt by additional skill",
+                    "resources": [
+                        {
+                            "item": "twisted-fang",
+                            "qty": 7
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
                         }
                     ]
                 },
@@ -157,12 +231,16 @@
                     "description": "+10% damage dealt by additional skill",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "blazing-soul",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -183,26 +261,44 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "twisted-fang",
+                            "qty": 5
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
                         }
                     ]
                 },
@@ -210,12 +306,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "twisted-fang",
+                            "qty": 7
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "blazing-soul",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -309,7 +426,7 @@
             ],
             "resources": [
                 {
-                    "item": "earth-rune",
+                    "item": "life-rune",
                     "qty": 10
                 }
             ]
@@ -330,11 +447,11 @@
             ],
             "resources": [
                 {
-                    "item": "earth-rune",
+                    "item": "life-rune",
                     "qty": 15
                 },
                 {
-                    "item": "greater-earth-rune",
+                    "item": "greater-life-rune",
                     "qty": 2
                 }
             ]
@@ -352,11 +469,11 @@
             ],
             "resources": [
                 {
-                    "item": "earth-rune",
+                    "item": "life-rune",
                     "qty": 20
                 },
                 {
-                    "item": "greater-earth-rune",
+                    "item": "greater-life-rune",
                     "qty": 10
                 }
             ]
@@ -377,11 +494,11 @@
             ],
             "resources": [
                 {
-                    "item": "greater-earth-rune",
+                    "item": "greater-life-rune",
                     "qty": 10
                 },
                 {
-                    "item": "epic-earth-rune",
+                    "item": "epic-life-rune",
                     "qty": 2
                 }
             ]
@@ -402,7 +519,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-earth-rune",
+                    "item": "epic-life-rune",
                     "qty": 6
                 },
                 {
@@ -427,7 +544,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-earth-rune",
+                    "item": "epic-life-rune",
                     "qty": 10
                 },
                 {

--- a/src/hero/yufine.json
+++ b/src/hero/yufine.json
@@ -81,26 +81,61 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% effect chance",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% effect chance",
+                    "resources": [
+                        {
+                            "item": "shiny-enchantment",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 22000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "shiny-enchantment",
+                            "qty": 4
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
                         }
                     ]
                 },
@@ -108,12 +143,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "shiny-enchantment",
+                            "qty": 5
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 45000
                         }
                     ]
                 },
@@ -121,18 +160,24 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "horn-of-desire",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_def_dn"]
+            "debuffs": [
+                "stic_def_dn"
+            ]
         },
         {
             "isPassive": false,
@@ -147,19 +192,63 @@
             "enhancement": [
                 {
                     "description": "+5% effect chance",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "shiny-enchantment",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 19000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "shiny-enchantment",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 45000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% effect chance",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "horn-of-desire",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 130000
+                        }
+                    ]
                 }
             ],
-            "buffs": ["stic_att_up", "stic_speed_up"],
-            "debuffs": ["stic_silence"]
+            "buffs": [
+                "stic_att_up",
+                "stic_speed_up"
+            ],
+            "debuffs": [
+                "stic_silence"
+            ]
         },
         {
             "isPassive": false,
@@ -174,26 +263,61 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "shiny-enchantment",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 22000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "shiny-enchantment",
+                            "qty": 4
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
                         }
                     ]
                 },
@@ -201,12 +325,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "shiny-enchantment",
+                            "qty": 5
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 45000
                         }
                     ]
                 },
@@ -214,18 +342,24 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "horn-of-desire",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_stun"]
+            "debuffs": [
+                "stic_stun"
+            ]
         }
     ],
     "specialtySkill": {
@@ -313,7 +447,7 @@
             ],
             "resources": [
                 {
-                    "item": "earth-rune",
+                    "item": "life-rune",
                     "qty": 10
                 }
             ]
@@ -334,11 +468,11 @@
             ],
             "resources": [
                 {
-                    "item": "earth-rune",
+                    "item": "life-rune",
                     "qty": 15
                 },
                 {
-                    "item": "greater-earth-rune",
+                    "item": "greater-life-rune",
                     "qty": 2
                 }
             ]
@@ -356,11 +490,11 @@
             ],
             "resources": [
                 {
-                    "item": "earth-rune",
+                    "item": "life-rune",
                     "qty": 20
                 },
                 {
-                    "item": "greater-earth-rune",
+                    "item": "greater-life-rune",
                     "qty": 10
                 }
             ]
@@ -381,11 +515,11 @@
             ],
             "resources": [
                 {
-                    "item": "greater-earth-rune",
+                    "item": "greater-life-rune",
                     "qty": 10
                 },
                 {
-                    "item": "epic-earth-rune",
+                    "item": "epic-life-rune",
                     "qty": 2
                 }
             ]
@@ -406,7 +540,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-earth-rune",
+                    "item": "epic-life-rune",
                     "qty": 6
                 },
                 {
@@ -431,7 +565,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-earth-rune",
+                    "item": "epic-life-rune",
                     "qty": 10
                 },
                 {

--- a/src/hero/yuna.json
+++ b/src/hero/yuna.json
@@ -77,26 +77,44 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 1
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "twisted-fang",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 22000
                         }
                     ]
                 },
@@ -104,12 +122,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "twisted-fang",
+                            "qty": 4
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "twisted-fang",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 45000
                         }
                     ]
                 },
@@ -117,12 +156,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "blazing-soul",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
                         }
                     ]
                 }
@@ -143,11 +186,37 @@
             "enhancement": [
                 {
                     "description": "+2 Soul acquired",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "twisted-fang",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "blazing-soul",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
+                        }
+                    ]
                 }
             ],
             "buffs": [],
@@ -166,26 +235,57 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 12000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "twisted-fang",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 27000
                         }
                     ]
                 },
@@ -193,12 +293,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "twisted-fang",
+                            "qty": 4
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
                         }
                     ]
                 },
@@ -206,12 +310,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "twisted-fang",
+                            "qty": 7
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
                         }
                     ]
                 },
@@ -219,12 +327,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "blazing-soul",
+                            "qty": 3
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 150000
                         }
                     ]
                 }
@@ -318,7 +430,7 @@
             ],
             "resources": [
                 {
-                    "item": "ice-rune",
+                    "item": "frost-rune",
                     "qty": 10
                 }
             ]
@@ -339,11 +451,11 @@
             ],
             "resources": [
                 {
-                    "item": "ice-rune",
+                    "item": "frost-rune",
                     "qty": 15
                 },
                 {
-                    "item": "greater-ice-rune",
+                    "item": "greater-frost-rune",
                     "qty": 2
                 }
             ]
@@ -361,11 +473,11 @@
             ],
             "resources": [
                 {
-                    "item": "ice-rune",
+                    "item": "frost-rune",
                     "qty": 20
                 },
                 {
-                    "item": "greater-ice-rune",
+                    "item": "greater-frost-rune",
                     "qty": 10
                 }
             ]
@@ -386,11 +498,11 @@
             ],
             "resources": [
                 {
-                    "item": "greater-ice-rune",
+                    "item": "greater-frost-rune",
                     "qty": 10
                 },
                 {
-                    "item": "epic-ice-rune",
+                    "item": "epic-frost-rune",
                     "qty": 2
                 }
             ]
@@ -411,7 +523,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-ice-rune",
+                    "item": "epic-frost-rune",
                     "qty": 6
                 },
                 {
@@ -436,7 +548,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-ice-rune",
+                    "item": "epic-frost-rune",
                     "qty": 10
                 },
                 {

--- a/src/hero/zeno.json
+++ b/src/hero/zeno.json
@@ -1,566 +1,566 @@
 {
-  "name": "Zeno",
-  "rarity": 5,
-  "classType": "mage",
-  "element": "ice",
-  "zodiac": "taurus",
-  "specialtyChangeName": "",
-  "selfSkillBarName": "",
-  "background": "An emperor from another galaxy who was defeated in a tournament held by Notos. He obsessed over power and life, eventually binding his soul with that of a star and becoming transcendent. He now heads toward Orbis in search of the Monolith.",
-  "relations": [
-    {
-      "hero": "kayron",
-      "relationType": "rival"
-    },
-    {
-      "hero": "ras",
-      "relationType": "rival"
-    }
-  ],
-  "stats": {
-    "base": {
-      "cp": 1477,
-      "atk": 89,
-      "hp": 292,
-      "spd": 111,
-      "def": 84,
-      "chc": 15,
-      "chd": 150,
-      "eff": 0,
-      "efr": 0,
-      "dac": 5
-    },
-    "max": {
-      "cp": 17185,
-      "atk": 1039,
-      "hp": 5299,
-      "spd": 115,
-      "def": 673,
-      "chc": 15,
-      "chd": 150,
-      "eff": 9,
-      "efr": 9,
-      "dac": 5
-    },
-    "max6": {
-      "cp": 15180,
-      "atk": 889,
-      "hp": 4879,
-      "spd": 111,
-      "def": 673,
-      "chc": 15,
-      "chd": 150,
-      "eff": 0,
-      "efr": 0,
-      "dac": 5
-    },
-    "max5": {
-      "cp": 12163,
-      "atk": 713,
-      "hp": 3881,
-      "spd": 111,
-      "def": 542,
-      "chc": 15,
-      "chd": 150,
-      "eff": 0,
-      "efr": 0,
-      "dac": 5
-    }
-  },
-  "skills": [
-    {
-      "isPassive": false,
-      "soulBurn": 0,
-      "selfSkillBarValue": 0,
-      "soulBurnEffect": "",
-      "awakenUpgrade": false,
-      "cooldown": 0,
-      "name": "Black Thorn",
-      "soulAcquire": 1,
-      "description": "Attacks with thorns, with a 25% chance to stun for 1 turn. Damage dealt increases proportional to the caster's max Health.",
-      "enhancement": [
+    "name": "Zeno",
+    "rarity": 5,
+    "classType": "mage",
+    "element": "ice",
+    "zodiac": "taurus",
+    "specialtyChangeName": "",
+    "selfSkillBarName": "",
+    "background": "An emperor from another galaxy who was defeated in a tournament held by Notos. He obsessed over power and life, eventually binding his soul with that of a star and becoming transcendent. He now heads toward Orbis in search of the Monolith.",
+    "relations": [
         {
-          "description": "+5% damage dealt",
-          "resources": [
-            {
-              "item": "molagora",
-              "qty": 1
-            },
-            {
-              "item": "gold",
-              "qty": 4000
-            }
-          ]
+            "hero": "kayron",
+            "relationType": "rival"
         },
         {
-          "description": "+5% effect chance",
-          "resources": [
-            {
-              "item": "molagora",
-              "qty": 2
-            },
-            {
-              "item": "gold",
-              "qty": 8000
-            }
-          ]
-        },
-        {
-          "description": "+10% damage dealt",
-          "resources": [
-            {
-              "item": "shiny-enchantment",
-              "qty": 5
-            },
-            {
-              "item": "molagora",
-              "qty": 3
-            },
-            {
-              "item": "gold",
-              "qty": 37000
-            }
-          ]
-        },
-        {
-          "description": "+5% effect chance",
-          "resources": [
-            {
-              "item": "shiny-enchantment",
-              "qty": 7
-            },
-            {
-              "item": "molagorago",
-              "qty": 1
-            },
-            {
-              "item": "gold",
-              "qty": 55000
-            }
-          ]
-        },
-        {
-          "description": "+15% damage dealt",
-          "resources": [
-            {
-              "item": "horn-of-desire",
-              "qty": 2
-            },
-            {
-              "item": "molagorago",
-              "qty": 3
-            },
-            {
-              "item": "gold",
-              "qty": 120000
-            }
-          ]
+            "hero": "ras",
+            "relationType": "rival"
         }
-      ],
-      "buffs": [],
-      "debuffs": [
-        "stic_stun"
-      ]
-    },
-    {
-      "isPassive": true,
-      "soulBurn": 0,
-      "selfSkillBarValue": 0,
-      "soulBurnEffect": "",
-      "awakenUpgrade": false,
-      "cooldown": 0,
-      "name": "Star's Armor",
-      "soulAcquire": 0,
-      "description": "Increases Defense and damage of Ancient Beast by 5.0% when the enemy uses a non-attack skill. Can stack up to 10 times.",
-      "enhancement": [
-        {
-          "description": "+0.5% effect",
-          "resources": [
-            {
-              "item": "molagora",
-              "qty": 1
-            },
-            {
-              "item": "gold",
-              "qty": 4000
-            }
-          ]
-        },
-        {
-          "description": "+0.5% effect",
-          "resources": [
-            {
-              "item": "molagora",
-              "qty": 2
-            },
-            {
-              "item": "gold",
-              "qty": 8000
-            }
-          ]
-        },
-        {
-          "description": "+0.5% effect",
-          "resources": [
-            {
-              "item": "shiny-enchantment",
-              "qty": 5
-            },
-            {
-              "item": "molagora",
-              "qty": 3
-            },
-            {
-              "item": "gold",
-              "qty": 37000
-            }
-          ]
-        },
-        {
-          "description": "+0.5% effect",
-          "resources": [
-            {
-              "item": "shiny-enchantment",
-              "qty": 7
-            },
-            {
-              "item": "molagorago",
-              "qty": 1
-            },
-            {
-              "item": "gold",
-              "qty": 55000
-            }
-          ]
-        },
-        {
-          "description": "+1% effect",
-          "resources": [
-            {
-              "item": "horn-of-desire",
-              "qty": 2
-            },
-            {
-              "item": "molagorago",
-              "qty": 3
-            },
-            {
-              "item": "gold",
-              "qty": 120000
-            }
-          ]
-        }
-      ],
-      "buffs": [],
-      "debuffs": []
-    },
-    {
-      "isPassive": false,
-      "soulBurn": 20,
-      "selfSkillBarValue": 0,
-      "soulBurnEffect": "Grants an extra turn.",
-      "awakenUpgrade": true,
-      "cooldown": 4,
-      "name": "Ancient Beast",
-      "soulAcquire": 2,
-      "description": "Summons an ancient beast to attack all enemies, with a 55% chance to silence for 1 turn and inflict bleeding for 2 turns. Damage dealt increases proportional to the caster's max Health.",
-      "enhancement": [
-        {
-          "description": "+5% damage dealt",
-          "resources": [
-            {
-              "item": "molagora",
-              "qty": 1
-            },
-            {
-              "item": "gold",
-              "qty": 4000
-            }
-          ]
-        },
-        {
-          "description": "+5% effect chance",
-          "resources": [
-            {
-              "item": "molagora",
-              "qty": 2
-            },
-            {
-              "item": "gold",
-              "qty": 8000
-            }
-          ]
-        },
-        {
-          "description": "+10% damage dealt",
-          "resources": [
-            {
-              "item": "shiny-enchantment",
-              "qty": 5
-            },
-            {
-              "item": "molagora",
-              "qty": 3
-            },
-            {
-              "item": "gold",
-              "qty": 37000
-            }
-          ]
-        },
-        {
-          "description": "+10% effect chance",
-          "resources": [
-            {
-              "item": "shiny-enchantment",
-              "qty": 7
-            },
-            {
-              "item": "molagorago",
-              "qty": 1
-            },
-            {
-              "item": "gold",
-              "qty": 55000
-            }
-          ]
-        },
-        {
-          "description": "+15% damage dealt",
-          "resources": [
-            {
-              "item": "horn-of-desire",
-              "qty": 2
-            },
-            {
-              "item": "molagorago",
-              "qty": 3
-            },
-            {
-              "item": "gold",
-              "qty": 120000
-            }
-          ]
-        }
-      ],
-      "buffs": [],
-      "debuffs": [
-        "stic_silence",
-        "stic_blood"
-      ]
-    }
-  ],
-  "specialtySkill": {
-    "name": "Planet Embezzler",
-    "description": "Driven to steal away the Monolith with the infinite might of a star.",
-    "dispatch": "[Time Limit] Attribute",
-    "enhancement": "Reward Bonus +10%",
+    ],
     "stats": {
-      "command": 86,
-      "charm": 15,
-      "politics": 79
-    }
-  },
-  "memoryImprintFormation": {
-    "north": true,
-    "south": true,
-    "east": true,
-    "west": true
-  },
-  "memoryImprint": [
-    {
-      "rank": "d",
-      "status": {
-        "type": "eff",
-        "increase": 0
-      }
+        "base": {
+            "cp": 1477,
+            "atk": 89,
+            "hp": 292,
+            "spd": 111,
+            "def": 84,
+            "chc": 15,
+            "chd": 150,
+            "eff": 0,
+            "efr": 0,
+            "dac": 5
+        },
+        "max": {
+            "cp": 17185,
+            "atk": 1039,
+            "hp": 5299,
+            "spd": 115,
+            "def": 673,
+            "chc": 15,
+            "chd": 150,
+            "eff": 9,
+            "efr": 9,
+            "dac": 5
+        },
+        "max6": {
+            "cp": 15180,
+            "atk": 889,
+            "hp": 4879,
+            "spd": 111,
+            "def": 673,
+            "chc": 15,
+            "chd": 150,
+            "eff": 0,
+            "efr": 0,
+            "dac": 5
+        },
+        "max5": {
+            "cp": 12163,
+            "atk": 713,
+            "hp": 3881,
+            "spd": 111,
+            "def": 542,
+            "chc": 15,
+            "chd": 150,
+            "eff": 0,
+            "efr": 0,
+            "dac": 5
+        }
     },
-    {
-      "rank": "c",
-      "status": {
-        "type": "eff",
-        "increase": 0
-      }
+    "skills": [
+        {
+            "isPassive": false,
+            "soulBurn": 0,
+            "selfSkillBarValue": 0,
+            "soulBurnEffect": "",
+            "awakenUpgrade": false,
+            "cooldown": 0,
+            "name": "Black Thorn",
+            "soulAcquire": 1,
+            "description": "Attacks with thorns, with a 25% chance to stun for 1 turn. Damage dealt increases proportional to the caster's max Health.",
+            "enhancement": [
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% effect chance",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "shiny-enchantment",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% effect chance",
+                    "resources": [
+                        {
+                            "item": "shiny-enchantment",
+                            "qty": 7
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
+                        }
+                    ]
+                },
+                {
+                    "description": "+15% damage dealt",
+                    "resources": [
+                        {
+                            "item": "horn-of-desire",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
+                        }
+                    ]
+                }
+            ],
+            "buffs": [],
+            "debuffs": [
+                "stic_stun"
+            ]
+        },
+        {
+            "isPassive": true,
+            "soulBurn": 0,
+            "selfSkillBarValue": 0,
+            "soulBurnEffect": "",
+            "awakenUpgrade": false,
+            "cooldown": 0,
+            "name": "Star's Armor",
+            "soulAcquire": 0,
+            "description": "Increases Defense and damage of Ancient Beast by 5.0% when the enemy uses a non-attack skill. Can stack up to 10 times.",
+            "enhancement": [
+                {
+                    "description": "+0.5% effect",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
+                },
+                {
+                    "description": "+0.5% effect",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+0.5% effect",
+                    "resources": [
+                        {
+                            "item": "shiny-enchantment",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
+                        }
+                    ]
+                },
+                {
+                    "description": "+0.5% effect",
+                    "resources": [
+                        {
+                            "item": "shiny-enchantment",
+                            "qty": 7
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
+                        }
+                    ]
+                },
+                {
+                    "description": "+1% effect",
+                    "resources": [
+                        {
+                            "item": "horn-of-desire",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
+                        }
+                    ]
+                }
+            ],
+            "buffs": [],
+            "debuffs": []
+        },
+        {
+            "isPassive": false,
+            "soulBurn": 20,
+            "selfSkillBarValue": 0,
+            "soulBurnEffect": "Grants an extra turn.",
+            "awakenUpgrade": true,
+            "cooldown": 4,
+            "name": "Ancient Beast",
+            "soulAcquire": 2,
+            "description": "Summons an ancient beast to attack all enemies, with a 55% chance to silence for 1 turn and inflict bleeding for 2 turns. Damage dealt increases proportional to the caster's max Health.",
+            "enhancement": [
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% effect chance",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "shiny-enchantment",
+                            "qty": 5
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 37000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% effect chance",
+                    "resources": [
+                        {
+                            "item": "shiny-enchantment",
+                            "qty": 7
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 55000
+                        }
+                    ]
+                },
+                {
+                    "description": "+15% damage dealt",
+                    "resources": [
+                        {
+                            "item": "horn-of-desire",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 120000
+                        }
+                    ]
+                }
+            ],
+            "buffs": [],
+            "debuffs": [
+                "stic_silence",
+                "stic_blood"
+            ]
+        }
+    ],
+    "specialtySkill": {
+        "name": "Planet Embezzler",
+        "description": "Driven to steal away the Monolith with the infinite might of a star.",
+        "dispatch": "[Time Limit] Attribute",
+        "enhancement": "Reward Bonus +10%",
+        "stats": {
+            "command": 86,
+            "charm": 15,
+            "politics": 79
+        }
     },
-    {
-      "rank": "b",
-      "status": {
-        "type": "eff",
-        "increase": 0.048
-      }
+    "memoryImprintFormation": {
+        "north": true,
+        "south": true,
+        "east": true,
+        "west": true
     },
-    {
-      "rank": "a",
-      "status": {
-        "type": "eff",
-        "increase": 0.072
-      }
-    },
-    {
-      "rank": "s",
-      "status": {
-        "type": "eff",
-        "increase": 0.096
-      }
-    },
-    {
-      "rank": "ss",
-      "status": {
-        "type": "eff",
-        "increase": 0.120
-      }
-    },
-    {
-      "rank": "sss",
-      "status": {
-        "type": "eff",
-        "increase": 0.144
-      }
-    }
-  ],
-  "awakening": [
-    {
-      "rank": 1,
-      "skillUpgrade": false,
-      "statsIncrease": [
+    "memoryImprint": [
         {
-          "efr": 0.03
+            "rank": "d",
+            "status": {
+                "type": "eff",
+                "increase": 0
+            }
         },
         {
-          "atk": 20
+            "rank": "c",
+            "status": {
+                "type": "eff",
+                "increase": 0
+            }
         },
         {
-          "hp": 60
+            "rank": "b",
+            "status": {
+                "type": "eff",
+                "increase": 0.048
+            }
+        },
+        {
+            "rank": "a",
+            "status": {
+                "type": "eff",
+                "increase": 0.072
+            }
+        },
+        {
+            "rank": "s",
+            "status": {
+                "type": "eff",
+                "increase": 0.096
+            }
+        },
+        {
+            "rank": "ss",
+            "status": {
+                "type": "eff",
+                "increase": 0.12
+            }
+        },
+        {
+            "rank": "sss",
+            "status": {
+                "type": "eff",
+                "increase": 0.144
+            }
         }
-      ],
-      "resources": [
+    ],
+    "awakening": [
         {
-          "item": "frost-rune",
-          "qty": 10
+            "rank": 1,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "efr": 0.03
+                },
+                {
+                    "atk": 20
+                },
+                {
+                    "hp": 60
+                }
+            ],
+            "resources": [
+                {
+                    "item": "frost-rune",
+                    "qty": 10
+                }
+            ]
+        },
+        {
+            "rank": 2,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "eff": 0.03
+                },
+                {
+                    "atk": 20
+                },
+                {
+                    "hp": 60
+                }
+            ],
+            "resources": [
+                {
+                    "item": "frost-rune",
+                    "qty": 15
+                },
+                {
+                    "item": "greater-frost-rune",
+                    "qty": 2
+                }
+            ]
+        },
+        {
+            "rank": 3,
+            "skillUpgrade": true,
+            "statsIncrease": [
+                {
+                    "atk": 20
+                },
+                {
+                    "hp": 60
+                }
+            ],
+            "resources": [
+                {
+                    "item": "frost-rune",
+                    "qty": 20
+                },
+                {
+                    "item": "greater-frost-rune",
+                    "qty": 10
+                }
+            ]
+        },
+        {
+            "rank": 4,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "spd": 4
+                },
+                {
+                    "atk": 30
+                },
+                {
+                    "hp": 80
+                }
+            ],
+            "resources": [
+                {
+                    "item": "greater-frost-rune",
+                    "qty": 10
+                },
+                {
+                    "item": "epic-frost-rune",
+                    "qty": 2
+                }
+            ]
+        },
+        {
+            "rank": 5,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "efr": 0.06
+                },
+                {
+                    "atk": 30
+                },
+                {
+                    "hp": 80
+                }
+            ],
+            "resources": [
+                {
+                    "item": "epic-frost-rune",
+                    "qty": 6
+                },
+                {
+                    "item": "blazing-rage",
+                    "qty": 15
+                }
+            ]
+        },
+        {
+            "rank": 6,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "eff": 0.06
+                },
+                {
+                    "atk": 30
+                },
+                {
+                    "hp": 80
+                }
+            ],
+            "resources": [
+                {
+                    "item": "epic-frost-rune",
+                    "qty": 10
+                },
+                {
+                    "item": "horn-of-desire",
+                    "qty": 10
+                }
+            ]
         }
-      ]
-    },
-    {
-      "rank": 2,
-      "skillUpgrade": false,
-      "statsIncrease": [
-        {
-          "eff": 0.03
-        },
-        {
-          "atk": 20
-        },
-        {
-          "hp": 60
-        }
-      ],
-      "resources": [
-        {
-          "item": "frost-rune",
-          "qty": 15
-        },
-        {
-          "item": "greater-frost-rune",
-          "qty": 2
-        }
-      ]
-    },
-    {
-      "rank": 3,
-      "skillUpgrade": true,
-      "statsIncrease": [
-        {
-          "atk": 20
-        },
-        {
-          "hp": 60
-        }
-      ],
-      "resources": [
-        {
-          "item": "frost-rune",
-          "qty": 20
-        },
-        {
-          "item": "greater-frost-rune",
-          "qty": 10
-        }
-      ]
-    },
-    {
-      "rank": 4,
-      "skillUpgrade": false,
-      "statsIncrease": [
-        {
-          "spd": 4
-        },
-        {
-          "atk": 30
-        },
-        {
-          "hp": 80
-        }
-      ],
-      "resources": [
-        {
-          "item": "greater-frost-rune",
-          "qty": 10
-        },
-        {
-          "item": "epic-frost-rune",
-          "qty": 2
-        }
-      ]
-    },
-    {
-      "rank": 5,
-      "skillUpgrade": false,
-      "statsIncrease": [
-        {
-          "efr": 0.06
-        },
-        {
-          "atk": 30
-        },
-        {
-          "hp": 80
-        }
-      ],
-      "resources": [
-        {
-          "item": "epic-frost-rune",
-          "qty": 6
-        },
-        {
-          "item": "blazing-rage",
-          "qty": 15
-        }
-      ]
-    },
-    {
-      "rank": 6,
-      "skillUpgrade": false,
-      "statsIncrease": [
-        {
-          "eff": 0.06
-        },
-        {
-          "atk": 30
-        },
-        {
-          "hp": 80
-        }
-      ],
-      "resources": [
-        {
-          "item": "epic-frost-rune",
-          "qty": 10
-        },
-        {
-          "item": "horn-of-desire",
-          "qty": 10
-        }
-      ]
-    }
-  ]
+    ]
 }


### PR DESCRIPTION
Now that the databuilder is working must smoother, I have imported and re-exported all 5* heroes that either did not have an owner or was already complete.

Almost everyone one, just made minor format changes. (Databuilder even found and fixed a few incorrect values.)

Two exceptions:
Cecilia - The enhancement descriptions were formatted oddly, so didn't import well, so had to copy that in separately.
Kayron - He was missed in intial basic description(forgot to add him to the wiki list that I based them off of).