### PR TITLE
Re-export 4 star

### DIFF
--- a/src/hero/angelica.json
+++ b/src/hero/angelica.json
@@ -92,11 +92,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "4000"
+                            "qty": 4000
                         }
                     ]
                 },
@@ -105,11 +105,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": "8000"
+                            "qty": 8000
                         }
                     ]
                 },
@@ -118,32 +118,32 @@
                     "resources": [
                         {
                             "item": "baby-mouse-insignia",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "molagora",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "17000"
+                            "qty": 17000
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": "35000"
-                        },
                         {
                             "item": "baby-mouse-insignia",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "molagorago",
-                            "qty": "1"
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -151,22 +151,24 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": "100000"
-                        },
-                        {
                             "item": "the-heart-of-hypocrisy",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "molagorago",
-                            "qty": "2"
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_stun"]
+            "debuffs": [
+                "stic_stun"
+            ]
         },
         {
             "isPassive": false,
@@ -184,11 +186,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "4000"
+                            "qty": 4000
                         }
                     ]
                 },
@@ -197,11 +199,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": "8000"
+                            "qty": 8000
                         }
                     ]
                 },
@@ -210,15 +212,15 @@
                     "resources": [
                         {
                             "item": "baby-mouse-insignia",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "molagora",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "17000"
+                            "qty": 17000
                         }
                     ]
                 },
@@ -227,15 +229,15 @@
                     "resources": [
                         {
                             "item": "baby-mouse-insignia",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "molagorago",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "35000"
+                            "qty": 35000
                         }
                     ]
                 },
@@ -243,16 +245,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": "100000"
-                        },
-                        {
                             "item": "the-heart-of-hypocrisy",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "molagorago",
-                            "qty": "2"
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -276,11 +278,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "4000"
+                            "qty": 4000
                         }
                     ]
                 },
@@ -289,11 +291,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": "8000"
+                            "qty": 8000
                         }
                     ]
                 },
@@ -302,15 +304,15 @@
                     "resources": [
                         {
                             "item": "baby-mouse-insignia",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "molagora",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "17000"
+                            "qty": 17000
                         }
                     ]
                 },
@@ -319,15 +321,15 @@
                     "resources": [
                         {
                             "item": "baby-mouse-insignia",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "molagorago",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "35000"
+                            "qty": 35000
                         }
                     ]
                 },
@@ -336,20 +338,23 @@
                     "resources": [
                         {
                             "item": "the-heart-of-hypocrisy",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "molagorago",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": "100000"
+                            "qty": 100000
                         }
                     ]
                 }
             ],
-            "buffs": ["stic_protect", "stic_debuf_impossible"],
+            "buffs": [
+                "stic_protect",
+                "stic_debuf_impossible"
+            ],
             "debuffs": []
         }
     ],
@@ -421,7 +426,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "hp": "3%"
+                    "hp": 0.03
                 },
                 {
                     "atk": "20"
@@ -433,7 +438,7 @@
             "resources": [
                 {
                     "item": "frost-rune",
-                    "qty": "8"
+                    "qty": 8
                 }
             ]
         },
@@ -442,7 +447,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "hp": "3%"
+                    "hp": 0.03
                 },
                 {
                     "atk": "20"
@@ -454,11 +459,11 @@
             "resources": [
                 {
                     "item": "frost-rune",
-                    "qty": "12"
+                    "qty": 12
                 },
                 {
                     "item": "greater-frost-rune",
-                    "qty": "2"
+                    "qty": 2
                 }
             ]
         },
@@ -476,11 +481,11 @@
             "resources": [
                 {
                     "item": "frost-rune",
-                    "qty": "17"
+                    "qty": 17
                 },
                 {
                     "item": "greater-frost-rune",
-                    "qty": "8"
+                    "qty": 8
                 }
             ]
         },
@@ -489,7 +494,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "def": "6%"
+                    "def": 0.06
                 },
                 {
                     "atk": "30"
@@ -501,11 +506,11 @@
             "resources": [
                 {
                     "item": "greater-frost-rune",
-                    "qty": "8"
+                    "qty": 8
                 },
                 {
                     "item": "epic-frost-rune",
-                    "qty": "1"
+                    "qty": 2
                 }
             ]
         },
@@ -514,7 +519,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "hp": "6%"
+                    "hp": 0.06
                 },
                 {
                     "atk": "30"
@@ -526,11 +531,11 @@
             "resources": [
                 {
                     "item": "epic-frost-rune",
-                    "qty": "5"
+                    "qty": 5
                 },
                 {
                     "item": "special-alarm-loop",
-                    "qty": "12"
+                    "qty": 12
                 }
             ]
         },
@@ -539,7 +544,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "hp": "6%"
+                    "hp": 0.06
                 },
                 {
                     "atk": "30"
@@ -551,11 +556,11 @@
             "resources": [
                 {
                     "item": "epic-frost-rune",
-                    "qty": "8"
+                    "qty": 8
                 },
                 {
                     "item": "the-heart-of-hypocrisy",
-                    "qty": "8"
+                    "qty": 8
                 }
             ]
         }

--- a/src/hero/armin.json
+++ b/src/hero/armin.json
@@ -97,12 +97,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 4000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
                         }
                     ]
                 },
@@ -110,35 +110,31 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 8000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
                 {
                     "description": "+5% effect chance",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": 12000
-                        },
                         {
                             "item": "molagora",
                             "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 12000
                         }
                     ]
                 },
                 {
                     "description": "+5% effect chance",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": 17000
-                        },
                         {
                             "item": "slime-jelly",
                             "qty": 1
@@ -146,16 +142,16 @@
                         {
                             "item": "molagora",
                             "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": 30000
-                        },
                         {
                             "item": "slime-jelly",
                             "qty": 2
@@ -163,16 +159,16 @@
                         {
                             "item": "molagora",
                             "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 30000
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": 45000
-                        },
                         {
                             "item": "slime-jelly",
                             "qty": 5
@@ -180,16 +176,16 @@
                         {
                             "item": "molagorago",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 45000
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": 100000
-                        },
                         {
                             "item": "dragons-wrath",
                             "qty": 2
@@ -197,12 +193,18 @@
                         {
                             "item": "molagorago",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_stun"]
+            "debuffs": [
+                "stic_stun"
+            ]
         },
         {
             "isPassive": false,
@@ -218,35 +220,31 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 4000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": 8000
-                        },
                         {
                             "item": "molagora",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": 17000
-                        },
                         {
                             "item": "slime-jelly",
                             "qty": 1
@@ -254,6 +252,10 @@
                         {
                             "item": "molagora",
                             "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -261,16 +263,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 30000
-                        },
-                        {
                             "item": "slime-jelly",
                             "qty": 2
                         },
                         {
                             "item": "molagora",
                             "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 30000
                         }
                     ]
                 },
@@ -278,16 +280,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 40000
-                        },
-                        {
                             "item": "slime-jelly",
                             "qty": 4
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
                         }
                     ]
                 },
@@ -295,22 +297,27 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 100000
-                        },
-                        {
                             "item": "dragons-wrath",
                             "qty": 2
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
             ],
-            "buffs": ["stic_def_up"],
-            "debuffs": ["stic_blind", "stic_dot"]
+            "buffs": [
+                "stic_def_up"
+            ],
+            "debuffs": [
+                "stic_blind",
+                "stic_dot"
+            ]
         },
         {
             "isPassive": false,
@@ -326,16 +333,16 @@
                     "description": "Acquire +1 Soul",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 27000
-                        },
-                        {
                             "item": "slime-jelly",
                             "qty": 3
                         },
                         {
                             "item": "molagora",
                             "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 27000
                         }
                     ]
                 },
@@ -343,29 +350,35 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 130000
-                        },
-                        {
                             "item": "dragons-wrath",
                             "qty": 1
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 50000
                         }
                     ]
                 }
             ],
-            "buffs": ["stic_protect"],
+            "buffs": [
+                "stic_protect"
+            ],
             "debuffs": []
         }
     ],
     "specialtySkill": {
         "name": "Agile Mercenaries",
         "description": "Handles requests with diligence and efficiency.",
-        "dispatch": ["[All missions] type mission"],
-        "enhancement": ["Time required -5%"],
+        "dispatch": [
+            "[All missions] type mission"
+        ],
+        "enhancement": [
+            "Time required -5%"
+        ],
         "stats": {
             "command": 78,
             "charm": 22,
@@ -429,7 +442,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "def": "3%"
+                    "def": 0.03
                 },
                 {
                     "atk": 20
@@ -450,7 +463,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "efr": "3%"
+                    "efr": 0.03
                 },
                 {
                     "atk": 20
@@ -497,7 +510,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "def": "6%"
+                    "def": 0.06
                 },
                 {
                     "atk": 30
@@ -513,7 +526,7 @@
                 },
                 {
                     "item": "epic-life-rune",
-                    "qty": 1
+                    "qty": 2
                 }
             ]
         },
@@ -522,7 +535,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "def": "6%"
+                    "def": 0.06
                 },
                 {
                     "atk": 30
@@ -547,7 +560,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "efr": "6%"
+                    "efr": 0.06
                 },
                 {
                     "atk": 30

--- a/src/hero/assassin-cartuja.json
+++ b/src/hero/assassin-cartuja.json
@@ -83,12 +83,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 4000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
                         }
                     ]
                 },
@@ -96,12 +96,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 8000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
@@ -109,16 +109,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -126,16 +126,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 35000
-                        },
-                        {
                             "item": "sharp-spearhead",
                             "qty": 3
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -143,22 +143,24 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 100000
-                        },
-                        {
                             "item": "black-curse-powder",
                             "qty": 2
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_blood"]
+            "debuffs": [
+                "stic_blood"
+            ]
         },
         {
             "isPassive": true,
@@ -175,25 +177,25 @@
                     "description": "+1% Combat Readiness",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 4000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
                         }
                     ]
                 },
                 {
                     "description": "+1% Combat Readiness",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": 8000
-                        },
                         {
                             "item": "molagora",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
@@ -201,16 +203,16 @@
                     "description": "+1% Combat Readiness",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -218,26 +220,22 @@
                     "description": "+1% Combat Readiness",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 35000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
                 {
                     "description": "+1% Combat Readiness",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": 100000
-                        },
                         {
                             "item": "black-curse-powder",
                             "qty": 2
@@ -245,6 +243,10 @@
                         {
                             "item": "molagorago",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -267,12 +269,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 4000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
                         }
                     ]
                 },
@@ -280,16 +282,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 8000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "shard-spearhead",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
@@ -297,16 +295,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -314,16 +312,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 35000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -331,22 +329,25 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_def_dn", "stic_stun"]
+            "debuffs": [
+                "stic_def_dn",
+                "stic_stun"
+            ]
         }
     ],
     "specialtySkill": {
@@ -417,7 +418,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "hp": "3%"
+                    "hp": 0.03
                 },
                 {
                     "atk": 20
@@ -438,7 +439,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "atk": "3%"
+                    "atk": 0.03
                 },
                 {
                     "atk": 20
@@ -485,7 +486,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "def": "6%"
+                    "def": 0.06
                 },
                 {
                     "atk": 30
@@ -501,7 +502,7 @@
                 },
                 {
                     "item": "epic-dark-rune",
-                    "qty": 1
+                    "qty": 2
                 }
             ]
         },
@@ -510,7 +511,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "hp": "6%"
+                    "hp": 0.06
                 },
                 {
                     "atk": 30
@@ -535,7 +536,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "atk": "6%"
+                    "atk": 0.06
                 },
                 {
                     "atk": 30

--- a/src/hero/assassin-cidd.json
+++ b/src/hero/assassin-cidd.json
@@ -1,0 +1,547 @@
+{
+    "name": "Assassin Cidd",
+    "rarity": 4,
+    "classType": "thief",
+    "element": "dark",
+    "zodiac": "aquarius",
+    "specialtyChangeName": "",
+    "selfSkillBarName": "",
+    "background": "A boy who spent his days looking for a place where he belonged, until Eligos took him in.",
+    "relations": [
+        {
+            "hero": "",
+            "relationType": ""
+        }
+    ],
+    "stats": {
+        "base": {
+            "cp": 0,
+            "atk": 0,
+            "hp": 0,
+            "spd": 0,
+            "def": 0,
+            "chc": 0,
+            "chd": 0,
+            "eff": 0,
+            "efr": 0,
+            "dac": 0
+        },
+        "max": {
+            "cp": 0,
+            "atk": 0,
+            "hp": 0,
+            "spd": 0,
+            "def": 0,
+            "chc": 0,
+            "chd": 0,
+            "eff": 0,
+            "efr": 0,
+            "dac": 5
+        }
+    },
+    "skills": [
+        {
+            "isPassive": false,
+            "soulBurn": 0,
+            "selfSkillBarValue": 0,
+            "soulBurnEffect": "",
+            "awakenUpgrade": false,
+            "cooldown": 0,
+            "name": "Slice",
+            "soulAcquire": 1,
+            "description": "Attacks with an axe, with a 40% chance to poison for 2 turns. Damage dealt increases proportional to the caster's Speed.",
+            "enhancement": [
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% effect chance",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "leather-sheath",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% effect chance",
+                    "resources": [
+                        {
+                            "item": "leather-sheath",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 30000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "leather-sheath",
+                            "qty": 4
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "fighter-medal",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
+                        }
+                    ]
+                }
+            ],
+            "buffs": [],
+            "debuffs": [
+                "stic_dot"
+            ]
+        },
+        {
+            "isPassive": true,
+            "soulBurn": 0,
+            "selfSkillBarValue": 0,
+            "soulBurnEffect": "",
+            "awakenUpgrade": false,
+            "cooldown": 0,
+            "name": "Swift Action",
+            "soulAcquire": 0,
+            "description": "When an enemy is defeated, targets the enemy with the least Health for 2 turns and increases Speed of the caster by 30% for 1 turn.",
+            "enhancement": [
+                {
+                    "description": "+5% Speed",
+                    "resources": [
+                        {
+                            "item": "leather-sheath",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 9000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% Speed",
+                    "resources": [
+                        {
+                            "item": "leather-sheath",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% Speed",
+                    "resources": [
+                        {
+                            "item": "fighter-medal",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 50000
+                        }
+                    ]
+                }
+            ],
+            "buffs": [],
+            "debuffs": [
+                "stic_sign"
+            ]
+        },
+        {
+            "isPassive": false,
+            "soulBurn": 10,
+            "selfSkillBarValue": 0,
+            "soulBurnEffect": "Increases damage dealt.",
+            "awakenUpgrade": true,
+            "cooldown": 4,
+            "name": "Execution",
+            "soulAcquire": 2,
+            "description": "Attacks the enemy with a powerful ground pound, silencing them for 1 turn and decreasing their Combat Readiness by 30%. Damage dealt increases proportional to the caster and the enemy's Speed.",
+            "enhancement": [
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "-1 turn cooldown",
+                    "resources": [
+                        {
+                            "item": "leather-sheath",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "leather-sheath",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 30000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "leather-sheath",
+                            "qty": 4
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "fighter-medal",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
+                        }
+                    ]
+                }
+            ],
+            "buffs": [],
+            "debuffs": [
+                "stic_silence"
+            ]
+        }
+    ],
+    "specialtySkill": {
+        "name": "Faithful Dog",
+        "description": "He will do whatever it takes to fulfill his given mission.",
+        "dispatch": [],
+        "enhancement": [],
+        "stats": {
+            "command": 21,
+            "charm": 72,
+            "politics": 55
+        }
+    },
+    "memoryImprintFormation": {
+        "north": false,
+        "south": false,
+        "east": false,
+        "west": false
+    },
+    "memoryImprint": [
+        {
+            "rank": "d",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
+        },
+        {
+            "rank": "c",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
+        },
+        {
+            "rank": "b",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
+        },
+        {
+            "rank": "a",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
+        },
+        {
+            "rank": "s",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
+        },
+        {
+            "rank": "ss",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
+        },
+        {
+            "rank": "sss",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
+        }
+    ],
+    "awakening": [
+        {
+            "rank": 1,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "": 0
+                },
+                {
+                    "atk": 20
+                },
+                {
+                    "hp": 60
+                }
+            ],
+            "resources": [
+                {
+                    "item": "dark-rune",
+                    "qty": 8
+                }
+            ]
+        },
+        {
+            "rank": 2,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "": 0
+                },
+                {
+                    "atk": 20
+                },
+                {
+                    "hp": 60
+                }
+            ],
+            "resources": [
+                {
+                    "item": "dark-rune",
+                    "qty": 12
+                },
+                {
+                    "item": "greater-dark-rune",
+                    "qty": 2
+                }
+            ]
+        },
+        {
+            "rank": 3,
+            "skillUpgrade": true,
+            "statsIncrease": [
+                {
+                    "atk": 20
+                },
+                {
+                    "hp": 60
+                }
+            ],
+            "resources": [
+                {
+                    "item": "dark-rune",
+                    "qty": 17
+                },
+                {
+                    "item": "greater-dark-rune",
+                    "qty": 8
+                }
+            ]
+        },
+        {
+            "rank": 4,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "": 0
+                },
+                {
+                    "atk": 30
+                },
+                {
+                    "hp": 80
+                }
+            ],
+            "resources": [
+                {
+                    "item": "greater-dark-rune",
+                    "qty": 8
+                },
+                {
+                    "item": "epic-dark-rune",
+                    "qty": 2
+                }
+            ]
+        },
+        {
+            "rank": 5,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "": 0
+                },
+                {
+                    "atk": 30
+                },
+                {
+                    "hp": 80
+                }
+            ],
+            "resources": [
+                {
+                    "item": "epic-dark-rune",
+                    "qty": 5
+                },
+                {
+                    "item": "order-of-the-shield-insignia",
+                    "qty": 12
+                }
+            ]
+        },
+        {
+            "rank": 6,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "": 0
+                },
+                {
+                    "atk": 30
+                },
+                {
+                    "hp": 80
+                }
+            ],
+            "resources": [
+                {
+                    "item": "epic-dark-rune",
+                    "qty": 8
+                },
+                {
+                    "item": "fighter-medal",
+                    "qty": 8
+                }
+            ]
+        }
+    ]
+}

--- a/src/hero/assassin-coli.json
+++ b/src/hero/assassin-coli.json
@@ -77,26 +77,65 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "shiny-enchantment",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 4
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 21000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "shiny-enchantment",
+                            "qty": 1
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 7
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 33000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "horn-of-desire",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 80000
                         }
                     ]
                 }
@@ -117,31 +156,73 @@
             "enhancement": [
                 {
                     "description": "+5% trigger chance",
-                    "resources": []
-                },
-                {
-                    "description": "+5% trigger chance",
-                    "resources": []
-                },
-                {
-                    "description": "+5% trigger chance",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% trigger chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "shiny-enchantment",
+                            "qty": 1
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 4
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 21000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% trigger chance",
+                    "resources": [
+                        {
+                            "item": "shiny-enchantment",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 7
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 33000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% trigger chance",
+                    "resources": [
+                        {
+                            "item": "horn-of-desire",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 80000
                         }
                     ]
                 }
             ],
-            "buffs": ["stic_att_up", "stic_hide"],
+            "buffs": [
+                "stic_att_up",
+                "stic_hide"
+            ],
             "debuffs": []
         },
         {
@@ -157,26 +238,57 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 12000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "shiny-enchantment",
+                            "qty": 1
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -184,12 +296,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "shiny-enchantment",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 30000
                         }
                     ]
                 },
@@ -197,12 +313,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "shiny-enchantment",
+                            "qty": 5
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 45000
                         }
                     ]
                 },
@@ -210,18 +330,25 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "horn-of-desire",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_stun", "stic_silence"]
+            "debuffs": [
+                "stic_stun",
+                "stic_silence"
+            ]
         }
     ],
     "specialtySkill": {

--- a/src/hero/auxiliary-lots.json
+++ b/src/hero/auxiliary-lots.json
@@ -77,26 +77,44 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 1
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "strange-jelly",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -104,12 +122,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "strange-jelly",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 30000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "strange-jelly",
+                            "qty": 4
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
                         }
                     ]
                 },
@@ -117,12 +156,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "ancient-creature-nucleus",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -143,15 +186,54 @@
             "enhancement": [
                 {
                     "description": "+5% Combat Readiness",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "strange-jelly",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 9000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% Combat Readiness",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "strange-jelly",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% Combat Readiness",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "ancient-creature-nucleus",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 50000
+                        }
+                    ]
                 }
             ],
             "buffs": [],
@@ -170,26 +252,61 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% effect chance",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "strange-jelly",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
                 },
                 {
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "strange-jelly",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 30000
                         }
                     ]
                 },
@@ -197,12 +314,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "strange-jelly",
+                            "qty": 4
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
                         }
                     ]
                 },
@@ -210,12 +331,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "ancient-creature-nucleus",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }

--- a/src/hero/blood-blade-karin.json
+++ b/src/hero/blood-blade-karin.json
@@ -77,26 +77,61 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+15% healing",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
+                },
+                {
+                    "description": "+15% healing",
+                    "resources": [
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -104,12 +139,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "black-curse-powder",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -130,26 +169,61 @@
             "enhancement": [
                 {
                     "description": "+5% stat increase",
-                    "resources": []
-                },
-                {
-                    "description": "+10% stat increase",
-                    "resources": []
-                },
-                {
-                    "description": "+10% stat increase",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% stat increase",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% stat increase",
+                    "resources": [
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% stat increase",
+                    "resources": [
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -157,12 +231,16 @@
                     "description": "+15% stat increase",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "black-curse-powder",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -183,26 +261,61 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -210,12 +323,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "black-curse-powder",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -431,7 +548,7 @@
                     "qty": 8
                 },
                 {
-                    "item": "black-cursed-powder",
+                    "item": "black-curse-powder",
                     "qty": 8
                 }
             ]

--- a/src/hero/celestial-mercedes.json
+++ b/src/hero/celestial-mercedes.json
@@ -127,12 +127,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 3
-                        },
-                        {
                             "item": "sharp-spearhead",
                             "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
                         },
                         {
                             "item": "gold",
@@ -144,12 +144,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
-                        {
                             "item": "sharp-spearhead",
                             "qty": 3
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
                         },
                         {
                             "item": "gold",
@@ -161,11 +161,11 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagorago",
+                            "item": "black-curse-powder",
                             "qty": 2
                         },
                         {
-                            "item": "black-curse-powder",
+                            "item": "molagorago",
                             "qty": 2
                         },
                         {
@@ -176,7 +176,9 @@
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_heal_impossible"]
+            "debuffs": [
+                "stic_heal_impossible"
+            ]
         },
         {
             "isPassive": false,
@@ -219,12 +221,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 3
-                        },
-                        {
                             "item": "sharp-spearhead",
                             "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
                         },
                         {
                             "item": "gold",
@@ -236,12 +238,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
-                        {
                             "item": "sharp-spearhead",
                             "qty": 3
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
                         },
                         {
                             "item": "gold",
@@ -253,11 +255,11 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagorago",
+                            "item": "black-curse-powder",
                             "qty": 2
                         },
                         {
-                            "item": "black-curse-powder",
+                            "item": "molagorago",
                             "qty": 2
                         },
                         {
@@ -311,12 +313,12 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 3
-                        },
-                        {
                             "item": "sharp-spearhead",
                             "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
                         },
                         {
                             "item": "gold",
@@ -328,12 +330,12 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
-                        {
                             "item": "sharp-spearhead",
                             "qty": 3
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
                         },
                         {
                             "item": "gold",
@@ -345,11 +347,11 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "molagorago",
+                            "item": "black-curse-powder",
                             "qty": 2
                         },
                         {
-                            "item": "black-curse-powder",
+                            "item": "molagorago",
                             "qty": 2
                         },
                         {
@@ -359,15 +361,21 @@
                     ]
                 }
             ],
-            "buffs": ["stic_att_inc"],
+            "buffs": [
+                "stic_att_inc"
+            ],
             "debuffs": []
         }
     ],
     "specialtySkill": {
         "name": "Good and Evil",
         "description": "There's a fine line between good and evil.",
-        "dispatch": ["[Sanctuary] Category"],
-        "enhancement": ["Time Required -6%"],
+        "dispatch": [
+            "[Sanctuary] Category"
+        ],
+        "enhancement": [
+            "Time Required -6%"
+        ],
         "stats": {
             "command": 64,
             "charm": 55,
@@ -424,7 +432,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "chc": "3%"
+                    "chc": 0.03
                 },
                 {
                     "atk": 20
@@ -445,7 +453,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "atk": "3%"
+                    "atk": 0.03
                 },
                 {
                     "atk": 20
@@ -492,7 +500,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "chd": "6%"
+                    "chd": 0.06
                 },
                 {
                     "atk": 30
@@ -508,7 +516,7 @@
                 },
                 {
                     "item": "epic-dark-rune",
-                    "qty": 1
+                    "qty": 2
                 }
             ]
         },
@@ -517,7 +525,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "chc": "6%"
+                    "chc": 0.06
                 },
                 {
                     "atk": 30
@@ -542,7 +550,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "atk": "6%"
+                    "atk": 0.06
                 },
                 {
                     "atk": 30

--- a/src/hero/challenger-dominiel.json
+++ b/src/hero/challenger-dominiel.json
@@ -85,35 +85,31 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 4000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": 8000
-                        },
                         {
                             "item": "molagora",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": 17000
-                        },
                         {
                             "item": "sharp-spearhead",
                             "qty": 1
@@ -121,6 +117,10 @@
                         {
                             "item": "molagora",
                             "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -128,16 +128,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 35000
-                        },
-                        {
                             "item": "sharp-spearhead",
                             "qty": 3
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -145,16 +145,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 100000
-                        },
-                        {
-                            "item": "black-powder-curse",
+                            "item": "black-curse-powder",
                             "qty": 2
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -176,35 +176,31 @@
                     "description": "+5% additional damage",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 4000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
                         }
                     ]
                 },
                 {
                     "description": "+5% additional damage",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": 8000
-                        },
                         {
                             "item": "molagora",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
                 {
                     "description": "+5% additional damage",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": 17000
-                        },
                         {
                             "item": "sharp-spearhead",
                             "qty": 1
@@ -212,16 +208,16 @@
                         {
                             "item": "molagora",
                             "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
                 {
                     "description": "+5% additional damage",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": 35000
-                        },
                         {
                             "item": "sharp-spearhead",
                             "qty": 3
@@ -229,6 +225,10 @@
                         {
                             "item": "molagorago",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -236,16 +236,16 @@
                     "description": "+10% additional damage",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 100000
-                        },
-                        {
-                            "item": "black-powder-curse",
+                            "item": "black-curse-powder",
                             "qty": 2
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -267,12 +267,12 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 4000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
                         }
                     ]
                 },
@@ -280,12 +280,12 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 8000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
@@ -293,26 +293,22 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 17000
-                        },
-                        {
                             "item": "sharp-spearhead",
                             "qty": 1
                         },
                         {
                             "item": "molagora",
                             "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
                 {
                     "description": "+3% Combat Readiness",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": 35000
-                        },
                         {
                             "item": "sharp-spearhead",
                             "qty": 3
@@ -320,6 +316,10 @@
                         {
                             "item": "molagorago",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -327,29 +327,35 @@
                     "description": "+3% Combat Readiness",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 100000
-                        },
-                        {
-                            "item": "black-powder-curse",
+                            "item": "black-curse-powder",
                             "qty": 2
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
             ],
-            "buffs": ["stic_cri_up"],
+            "buffs": [
+                "stic_cri_up"
+            ],
             "debuffs": []
         }
     ],
     "specialtySkill": {
         "name": "Echo",
         "description": "Dreams about her voice ringing out across continents.",
-        "dispatch": ["[Gathering] Attribute"],
-        "enhancement": ["Reward Bonus +10%"],
+        "dispatch": [
+            "[Gathering] Attribute"
+        ],
+        "enhancement": [
+            "Reward Bonus +10%"
+        ],
         "stats": {
             "command": 32,
             "charm": 82,
@@ -413,7 +419,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "chc": "3%"
+                    "chc": 0.03
                 },
                 {
                     "atk": 20
@@ -434,7 +440,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "atk": "3%"
+                    "atk": 0.03
                 },
                 {
                     "atk": 20
@@ -481,7 +487,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "chd": "6%"
+                    "chd": 0.06
                 },
                 {
                     "atk": 30
@@ -497,7 +503,7 @@
                 },
                 {
                     "item": "epic-dark-rune",
-                    "qty": 1
+                    "qty": 2
                 }
             ]
         },
@@ -506,7 +512,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "chc": "6%"
+                    "chc": 0.06
                 },
                 {
                     "atk": 30
@@ -531,7 +537,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "atk": "6%"
+                    "atk": 0.06
                 },
                 {
                     "atk": 30
@@ -547,7 +553,7 @@
                 },
                 {
                     "item": "black-curse-powder",
-                    "qty": 6
+                    "qty": 8
                 }
             ]
         }

--- a/src/hero/cidd.json
+++ b/src/hero/cidd.json
@@ -89,25 +89,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 4000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
                         {
                             "item": "gold",
                             "qty": 8000
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
                         }
                     ]
                 },
@@ -115,16 +115,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 17000
-                        },
-                        {
-                            "item": "path power loop",
+                            "item": "path-power-loop",
                             "qty": 1
                         },
                         {
                             "item": "molagora",
                             "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -132,16 +132,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 35000
-                        },
-                        {
-                            "item": "path power loop",
+                            "item": "path-power-loop",
                             "qty": 3
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -149,21 +149,23 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 100000
-                        },
-                        {
-                            "item": "nightmare mask",
+                            "item": "nightmare-mask",
                             "qty": 2
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
             ],
-            "buffs": ["stic_spd_up"],
+            "buffs": [
+                "stic_spd_up"
+            ],
             "debuffs": []
         },
         {
@@ -180,25 +182,25 @@
                     "description": "+5% damage dealt by Relentless Strike",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 4000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt by Relentless Strike",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": 8000
-                        },
                         {
                             "item": "molagora",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
@@ -206,16 +208,16 @@
                     "description": "+5% damage dealt by Relentless Strike",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 17000
-                        },
-                        {
-                            "item": "path power loop",
+                            "item": "path-power-loop",
                             "qty": 1
                         },
                         {
                             "item": "molagora",
                             "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -223,16 +225,16 @@
                     "description": "+10% damage dealt by Relentless Strike",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 35000
-                        },
-                        {
-                            "item": "path power loop",
+                            "item": "path-power-loop",
                             "qty": 3
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -240,21 +242,23 @@
                     "description": "+15% damage dealt by Relentless Strike",
                     "resources": [
                         {
+                            "item": "nightmare-mask",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
                             "item": "gold",
                             "qty": 100000
-                        },
-                        {
-                            "item": "nightmare mask",
-                            "qty": 2
-                        },
-                        {
-                            "item": "molagoragora",
-                            "qty": 2
                         }
                     ]
                 }
             ],
-            "buffs": ["stic_spd_up"],
+            "buffs": [
+                "stic_spd_up"
+            ],
             "debuffs": []
         },
         {
@@ -271,12 +275,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 4000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
                         }
                     ]
                 },
@@ -284,12 +288,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 8000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
@@ -297,16 +301,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 17000
-                        },
-                        {
-                            "item": "path power loop",
+                            "item": "path-power-loop",
                             "qty": 1
                         },
                         {
                             "item": "molagora",
                             "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -314,16 +318,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 35000
-                        },
-                        {
-                            "item": "path power loop",
+                            "item": "path-power-loop",
                             "qty": 3
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -331,29 +335,35 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
+                            "item": "nightmare-mask",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
                             "item": "gold",
                             "qty": 100000
-                        },
-                        {
-                            "item": "nightmare mask",
-                            "qty": 2
-                        },
-                        {
-                            "item": "molagoragora",
-                            "qty": 2
                         }
                     ]
                 }
             ],
-            "buffs": ["stic_spd_up"],
+            "buffs": [
+                "stic_spd_up"
+            ],
             "debuffs": []
         }
     ],
     "specialtySkill": {
         "name": "Animal Instinct",
         "description": "Oustanding senses of smell and hearing are very helpful when hunting.",
-        "dispatch": ["[Adventure] type mission"],
-        "enhancement": ["Time requiered -6%"],
+        "dispatch": [
+            "[Adventure] type mission"
+        ],
+        "enhancement": [
+            "Time requiered -6%"
+        ],
         "stats": {
             "command": 45,
             "charm": 90,
@@ -417,7 +427,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "atk": "3%"
+                    "atk": 0.03
                 },
                 {
                     "atk": 20
@@ -485,7 +495,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "chc": "6%"
+                    "chc": 0.06
                 },
                 {
                     "atk": 30
@@ -501,7 +511,7 @@
                 },
                 {
                     "item": "epic-life-rune",
-                    "qty": 1
+                    "qty": 2
                 }
             ]
         },
@@ -510,7 +520,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "atk": "6%"
+                    "atk": 0.06
                 },
                 {
                     "atk": 30

--- a/src/hero/clarissa.json
+++ b/src/hero/clarissa.json
@@ -172,7 +172,9 @@
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_def_dn"]
+            "debuffs": [
+                "stic_def_dn"
+            ]
         },
         {
             "isPassive": true,
@@ -356,7 +358,9 @@
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_blood"]
+            "debuffs": [
+                "stic_blood"
+            ]
         }
     ],
     "specialtySkill": {
@@ -427,7 +431,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "atk": "3%"
+                    "atk": 0.03
                 },
                 {
                     "atk": 20
@@ -448,7 +452,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "atk": "3%"
+                    "atk": 0.03
                 },
                 {
                     "atk": 20
@@ -495,7 +499,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "chc": "6%"
+                    "chc": 0.06
                 },
                 {
                     "atk": 30
@@ -511,7 +515,7 @@
                 },
                 {
                     "item": "epic-frost-rune",
-                    "qty": 1
+                    "qty": 2
                 }
             ]
         },
@@ -520,7 +524,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "atk": "6%"
+                    "atk": 0.06
                 },
                 {
                     "atk": 30
@@ -545,7 +549,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "atk": "6%"
+                    "atk": 0.06
                 },
                 {
                     "atk": 30

--- a/src/hero/coli.json
+++ b/src/hero/coli.json
@@ -263,7 +263,10 @@
                     ]
                 }
             ],
-            "buffs": ["stic_hide", "stic_protect"],
+            "buffs": [
+                "stic_hide",
+                "stic_protect"
+            ],
             "debuffs": []
         },
         {
@@ -355,15 +358,23 @@
                     ]
                 }
             ],
-            "buffs": ["stic_hide"],
-            "debuffs": ["stic_stun"]
+            "buffs": [
+                "stic_hide"
+            ],
+            "debuffs": [
+                "stic_stun"
+            ]
         }
     ],
     "specialtySkill": {
         "name": "Life of Frugality",
         "description": "Has always dreamed of using her savings to build a new village for everyone.",
-        "dispatch": ["All Missions"],
-        "enhancement": ["Gold Bonus +6%"],
+        "dispatch": [
+            "All Missions"
+        ],
+        "enhancement": [
+            "Gold Bonus +6%"
+        ],
         "stats": {
             "command": 55,
             "charm": 68,
@@ -427,7 +438,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "atk": "3%"
+                    "atk": 0.03
                 },
                 {
                     "atk": "20"
@@ -448,7 +459,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "hp": "3%"
+                    "hp": 0.03
                 },
                 {
                     "atk": "20"
@@ -495,7 +506,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "chc": "6%"
+                    "chc": 0.06
                 },
                 {
                     "atk": "30"
@@ -511,7 +522,7 @@
                 },
                 {
                     "item": "epic-frost-rune",
-                    "qty": 1
+                    "qty": 2
                 }
             ]
         },
@@ -520,7 +531,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "atk": "6%"
+                    "atk": 0.06
                 },
                 {
                     "atk": "30"
@@ -545,7 +556,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "hp": "6%"
+                    "hp": 0.06
                 },
                 {
                     "atk": "30"

--- a/src/hero/crimson-armin.json
+++ b/src/hero/crimson-armin.json
@@ -77,26 +77,61 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% effect chance",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "mysterious-flash",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% effect chance",
+                    "resources": [
+                        {
+                            "item": "mysterious-flash",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 30000
                         }
                     ]
                 },
@@ -104,12 +139,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "mysterious-flash",
+                            "qty": 4
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
                         }
                     ]
                 },
@@ -117,18 +156,24 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "reingar-student-id",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_provoke"]
+            "debuffs": [
+                "stic_provoke"
+            ]
         },
         {
             "isPassive": true,
@@ -143,26 +188,57 @@
             "enhancement": [
                 {
                     "description": "+1% additional damage reduction",
-                    "resources": []
-                },
-                {
-                    "description": "+1% additional damage reduction",
-                    "resources": []
-                },
-                {
-                    "description": "+1% additional damage reduction",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+1% additional damage reduction",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+1% additional damage reduction",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 12000
+                        }
+                    ]
+                },
+                {
+                    "description": "+1% additional damage reduction",
+                    "resources": [
+                        {
+                            "item": "mysterious-flash",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -170,12 +246,16 @@
                     "description": "+2% additional damage reduction",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "mysterious-flash",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 30000
                         }
                     ]
                 },
@@ -183,12 +263,16 @@
                     "description": "+2% additional damage reduction",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "mysterious-flash",
+                            "qty": 5
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 45000
                         }
                     ]
                 },
@@ -196,12 +280,16 @@
                     "description": "+2% additional damage reduction",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "reingar-student-id",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -222,14 +310,43 @@
             "enhancement": [
                 {
                     "description": "+2 Soul acquired",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "mysterious-flash",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 27000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "reingar-student-id",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 50000
+                        }
+                    ]
                 }
             ],
-            "buffs": ["stic_invincible", "stic_debuf_impossible"],
+            "buffs": [
+                "stic_invincible",
+                "stic_debuf_impossible"
+            ],
             "debuffs": []
         }
     ],

--- a/src/hero/crozet.json
+++ b/src/hero/crozet.json
@@ -167,7 +167,9 @@
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_att_dn"]
+            "debuffs": [
+                "stic_att_dn"
+            ]
         },
         {
             "isPassive": true,
@@ -245,7 +247,9 @@
                     ]
                 }
             ],
-            "buffs": ["stic_protect"],
+            "buffs": [
+                "stic_protect"
+            ],
             "debuffs": []
         },
         {
@@ -439,7 +443,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "hp": "3%"
+                    "hp": 0.03
                 },
                 {
                     "atk": 20
@@ -460,7 +464,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "def": "3%"
+                    "def": 0.03
                 },
                 {
                     "atk": 20
@@ -507,7 +511,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "hp": "6%"
+                    "hp": 0.06
                 },
                 {
                     "atk": 30
@@ -523,7 +527,7 @@
                 },
                 {
                     "item": "epic-frost-rune",
-                    "qty": 1
+                    "qty": 2
                 }
             ]
         },
@@ -532,7 +536,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "hp": "6%"
+                    "hp": 0.06
                 },
                 {
                     "atk": 30
@@ -557,7 +561,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "def": "6%"
+                    "def": 0.06
                 },
                 {
                     "atk": 30

--- a/src/hero/dingo.json
+++ b/src/hero/dingo.json
@@ -177,7 +177,9 @@
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_blood"]
+            "debuffs": [
+                "stic_blood"
+            ]
         },
         {
             "isPassive": false,
@@ -299,7 +301,9 @@
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_blaze"]
+            "debuffs": [
+                "stic_blaze"
+            ]
         },
         {
             "isPassive": false,
@@ -419,7 +423,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "eff": "3%"
+                    "eff": 0.03
                 },
                 {
                     "atk": 20
@@ -440,7 +444,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "chc": "3%"
+                    "chc": 0.03
                 },
                 {
                     "atk": 20
@@ -503,7 +507,7 @@
                 },
                 {
                     "item": "epic-flame-rune",
-                    "qty": 1
+                    "qty": 2
                 }
             ]
         },
@@ -512,7 +516,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "eff": "6%"
+                    "eff": 0.06
                 },
                 {
                     "atk": 30
@@ -537,7 +541,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "chc": "6%"
+                    "chc": 0.06
                 },
                 {
                     "atk": 30

--- a/src/hero/dominiel.json
+++ b/src/hero/dominiel.json
@@ -88,11 +88,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "4000"
+                            "qty": 4000
                         }
                     ]
                 },
@@ -101,11 +101,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": "8000"
+                            "qty": 8000
                         }
                     ]
                 },
@@ -114,15 +114,15 @@
                     "resources": [
                         {
                             "item": "shiny-enchantment",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "molagora",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "17000"
+                            "qty": 17000
                         }
                     ]
                 },
@@ -131,15 +131,15 @@
                     "resources": [
                         {
                             "item": "shiny-enchantment",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "molagora",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "gold",
-                            "qty": "30000"
+                            "qty": 30000
                         }
                     ]
                 },
@@ -148,15 +148,15 @@
                     "resources": [
                         {
                             "item": "shiny-enchantment",
-                            "qty": "4"
+                            "qty": 4
                         },
                         {
                             "item": "molagorago",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "40000"
+                            "qty": 40000
                         }
                     ]
                 },
@@ -165,21 +165,23 @@
                     "resources": [
                         {
                             "item": "horn-of-desire",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "molagorago",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": "100000"
+                            "qty": 100000
                         }
                     ]
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_speed_dn"]
+            "debuffs": [
+                "stic_speed_dn"
+            ]
         },
         {
             "isPassive": false,
@@ -197,15 +199,15 @@
                     "resources": [
                         {
                             "item": "shiny-enchantment",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "molagora",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "27000"
+                            "qty": 27000
                         }
                     ]
                 },
@@ -214,20 +216,22 @@
                     "resources": [
                         {
                             "item": "horn-of-desire",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "molagorago",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "50000"
+                            "qty": 50000
                         }
                     ]
                 }
             ],
-            "buffs": ["stic_protect"],
+            "buffs": [
+                "stic_protect"
+            ],
             "debuffs": []
         },
         {
@@ -246,11 +250,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "4000"
+                            "qty": 4000
                         }
                     ]
                 },
@@ -259,11 +263,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": "8000"
+                            "qty": 8000
                         }
                     ]
                 },
@@ -272,11 +276,11 @@
                     "resources": [
                         {
                             "item": "molagora",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "12000"
+                            "qty": 12000
                         }
                     ]
                 },
@@ -285,15 +289,15 @@
                     "resources": [
                         {
                             "item": "shiny-enchantment",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "molagora",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
                             "item": "gold",
-                            "qty": "17000"
+                            "qty": 17000
                         }
                     ]
                 },
@@ -302,15 +306,15 @@
                     "resources": [
                         {
                             "item": "shiny-enchantment",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "molagora",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "gold",
-                            "qty": "30000"
+                            "qty": 30000
                         }
                     ]
                 },
@@ -319,15 +323,15 @@
                     "resources": [
                         {
                             "item": "shiny-enchantment",
-                            "qty": "5"
+                            "qty": 5
                         },
                         {
                             "item": "molagorago",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
                             "item": "gold",
-                            "qty": "45000"
+                            "qty": 45000
                         }
                     ]
                 },
@@ -336,21 +340,23 @@
                     "resources": [
                         {
                             "item": "horn-of-desire",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "molagorago",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
                             "item": "gold",
-                            "qty": "100000"
+                            "qty": 100000
                         }
                     ]
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_stun"]
+            "debuffs": [
+                "stic_stun"
+            ]
         }
     ],
     "specialtySkill": {
@@ -363,6 +369,12 @@
             "charm": "51",
             "politics": "32"
         }
+    },
+    "memoryImprintFormation": {
+        "north": true,
+        "south": true,
+        "east": true,
+        "west": true
     },
     "memoryImprint": [
         {
@@ -421,7 +433,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "eff": "3%"
+                    "eff": 0.03
                 },
                 {
                     "atk": "20"
@@ -433,7 +445,7 @@
             "resources": [
                 {
                     "item": "frost-rune",
-                    "qty": "8"
+                    "qty": 8
                 }
             ]
         },
@@ -442,7 +454,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "eff": "3%"
+                    "eff": 0.03
                 },
                 {
                     "atk": "20"
@@ -454,11 +466,11 @@
             "resources": [
                 {
                     "item": "frost-rune",
-                    "qty": "12"
+                    "qty": 12
                 },
                 {
                     "item": "greater-frost-rune",
-                    "qty": "2"
+                    "qty": 2
                 }
             ]
         },
@@ -476,11 +488,11 @@
             "resources": [
                 {
                     "item": "frost-rune",
-                    "qty": "17"
+                    "qty": 17
                 },
                 {
                     "item": "greater-frost-rune",
-                    "qty": "8"
+                    "qty": 8
                 }
             ]
         },
@@ -501,11 +513,11 @@
             "resources": [
                 {
                     "item": "greater-frost-rune",
-                    "qty": "8"
+                    "qty": 8
                 },
                 {
                     "item": "epic-frost-rune",
-                    "qty": "1"
+                    "qty": 2
                 }
             ]
         },
@@ -514,7 +526,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "efr": "6%"
+                    "efr": 0.06
                 },
                 {
                     "atk": "30"
@@ -526,11 +538,11 @@
             "resources": [
                 {
                     "item": "epic-frost-rune",
-                    "qty": "5"
+                    "qty": 5
                 },
                 {
                     "item": "blazing-rage",
-                    "qty": "12"
+                    "qty": 12
                 }
             ]
         },
@@ -539,7 +551,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "eff": "6%"
+                    "eff": 0.06
                 },
                 {
                     "atk": "30"
@@ -551,19 +563,13 @@
             "resources": [
                 {
                     "item": "epic-frost-rune",
-                    "qty": "8"
+                    "qty": 8
                 },
                 {
                     "item": "horn-of-desire",
-                    "qty": "8"
+                    "qty": 8
                 }
             ]
         }
-    ],
-    "memoryImprintFormation": {
-        "north": true,
-        "south": true,
-        "east": true,
-        "west": true
-    }
+    ]
 }

--- a/src/hero/fighter-maya.json
+++ b/src/hero/fighter-maya.json
@@ -83,25 +83,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 4000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": 8000
-                        },
                         {
                             "item": "molagora",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
@@ -109,16 +109,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "mysterious-flash",
+                            "qty": 1
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "mysterious-flash",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -126,16 +126,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 35000
+                            "item": "mysterious-flash",
+                            "qty": 3
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "mysterious-flash",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -143,22 +143,24 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "reingar-student-id",
+                            "qty": 2
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "reingar-student-id",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_provoke"]
+            "debuffs": [
+                "stic_provoke"
+            ]
         },
         {
             "isPassive": true,
@@ -175,12 +177,12 @@
                     "description": "+3% trigger chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 4000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
                         }
                     ]
                 },
@@ -188,12 +190,12 @@
                     "description": "+3% trigger chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 8000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
@@ -201,33 +203,33 @@
                     "description": "+4% trigger chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "mysterious-flash",
+                            "qty": 1
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "mysterious-flash",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
                 {
                     "description": "+5% trigger chance",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": 35000
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "mysterious-flash",
                             "qty": 3
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -235,21 +237,23 @@
                     "description": "+5% trigger chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "reingar-student-id",
+                            "qty": 2
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "reingar-student-id",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
             ],
-            "buffs": ["stic_def_up"],
+            "buffs": [
+                "stic_def_up"
+            ],
             "debuffs": []
         },
         {
@@ -267,12 +271,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 4000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
                         }
                     ]
                 },
@@ -280,12 +284,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 8000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
@@ -293,33 +297,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "mysterious-flash",
+                            "qty": 1
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "mysterious-flash",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": 35000
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "mysterious-flash",
                             "qty": 3
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -327,16 +331,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "reingar-student-id",
+                            "qty": 2
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "reingar-studet-id",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -413,7 +417,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "hp": "3%"
+                    "hp": 0.03
                 },
                 {
                     "atk": 20
@@ -434,7 +438,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "def": "3%"
+                    "def": 0.03
                 },
                 {
                     "atk": 20
@@ -467,12 +471,12 @@
             ],
             "resources": [
                 {
-                    "item": "greater-light-rune",
-                    "qty": 8
-                },
-                {
                     "item": "light-rune",
                     "qty": 17
+                },
+                {
+                    "item": "greater-light-rune",
+                    "qty": 8
                 }
             ]
         },
@@ -481,7 +485,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "efr": "6%"
+                    "efr": 0.06
                 },
                 {
                     "atk": 30
@@ -497,7 +501,7 @@
                 },
                 {
                     "item": "epic-light-rune",
-                    "qty": 1
+                    "qty": 2
                 }
             ]
         },
@@ -506,7 +510,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "hp": "6%"
+                    "hp": 0.06
                 },
                 {
                     "atk": 30
@@ -531,7 +535,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "def": "6%"
+                    "def": 0.06
                 },
                 {
                     "atk": 30

--- a/src/hero/general-purrgis.json
+++ b/src/hero/general-purrgis.json
@@ -77,26 +77,61 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% effect chance",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% effect chance",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "baby-mouse-insignia",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 30000
                         }
                     ]
                 },
@@ -104,12 +139,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "baby-mouse-insignia",
+                            "qty": 4
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
                         }
                     ]
                 },
@@ -117,12 +156,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -143,15 +186,54 @@
             "enhancement": [
                 {
                     "description": "+1% Combat Readiness",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 9000
+                        }
+                    ]
                 },
                 {
                     "description": "+2% Combat Readiness",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "baby-mouse-insignia",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
+                        }
+                    ]
                 },
                 {
                     "description": "+2% Combat Readiness",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 50000
+                        }
+                    ]
                 }
             ],
             "buffs": [],
@@ -170,26 +252,61 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% effect chance",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
                 },
                 {
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "baby-mouse-insignia",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 30000
                         }
                     ]
                 },
@@ -197,12 +314,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "baby-mouse-insignia",
+                            "qty": 4
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
                         }
                     ]
                 },
@@ -210,12 +331,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }

--- a/src/hero/guider-aither.json
+++ b/src/hero/guider-aither.json
@@ -1,0 +1,539 @@
+{
+    "name": "Guider Aither",
+    "rarity": 4,
+    "classType": "mage",
+    "element": "light",
+    "zodiac": "cancer",
+    "specialtyChangeName": "",
+    "selfSkillBarName": "",
+    "background": "An ever-cheerful traveler, Aither loves life on the road. As he embarks on a journey to find his lost memories, he is often followed by small animals.",
+    "relations": [
+        {
+            "hero": "",
+            "relationType": ""
+        }
+    ],
+    "stats": {
+        "base": {
+            "cp": 0,
+            "atk": 0,
+            "hp": 0,
+            "spd": 0,
+            "def": 0,
+            "chc": 0,
+            "chd": 0,
+            "eff": 0,
+            "efr": 0,
+            "dac": 0
+        },
+        "max": {
+            "cp": 0,
+            "atk": 0,
+            "hp": 0,
+            "spd": 0,
+            "def": 0,
+            "chc": 0,
+            "chd": 0,
+            "eff": 0,
+            "efr": 0,
+            "dac": 5
+        }
+    },
+    "skills": [
+        {
+            "isPassive": false,
+            "soulBurn": 0,
+            "selfSkillBarValue": 0,
+            "soulBurnEffect": "",
+            "awakenUpgrade": false,
+            "cooldown": 0,
+            "name": "Whispering Spirit",
+            "soulAcquire": 1,
+            "description": "Attacks with spirit power, with a 25% chance to decrease Speed for 2 turns.",
+            "enhancement": [
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% effect chance",
+                    "resources": [
+                        {
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
+                },
+                {
+                    "description": "+15% effect chance",
+                    "resources": [
+                        {
+                            "item": "baby-mouse-insignia",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
+                        }
+                    ]
+                },
+                {
+                    "description": "+15% damage dealt",
+                    "resources": [
+                        {
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
+                        }
+                    ]
+                }
+            ],
+            "buffs": [],
+            "debuffs": [
+                "stic_speed_dn"
+            ]
+        },
+        {
+            "isPassive": false,
+            "soulBurn": 0,
+            "selfSkillBarValue": 0,
+            "soulBurnEffect": "",
+            "awakenUpgrade": false,
+            "cooldown": 3,
+            "name": "Spirit's Protection",
+            "soulAcquire": 2,
+            "description": "Attacks with spirit power, and grants caster a barrier for 2 turns. Barrier strength is proportional to the caster's Attack.",
+            "enhancement": [
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "baby-mouse-insignia",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
+                        }
+                    ]
+                }
+            ],
+            "buffs": [
+                "stic_protect"
+            ],
+            "debuffs": []
+        },
+        {
+            "isPassive": false,
+            "soulBurn": 10,
+            "selfSkillBarValue": 0,
+            "soulBurnEffect": "Increases damage dealt.",
+            "awakenUpgrade": true,
+            "cooldown": 5,
+            "name": "Wave of Force",
+            "soulAcquire": 2,
+            "description": "Delivers a blow to the enemy with the Energy of Souls, recovering Health of all allies. All allies are granted continuous healing for 2 turns. Amount healed increased proportional to damage dealt.",
+            "enhancement": [
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
+                },
+                {
+                    "description": "+20% healing",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "-1 turn cooldown",
+                    "resources": [
+                        {
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "baby-mouse-insignia",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
+                        }
+                    ]
+                },
+                {
+                    "description": "+15% damage dealt",
+                    "resources": [
+                        {
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
+                        }
+                    ]
+                }
+            ],
+            "buffs": [
+                "stic_heal"
+            ],
+            "debuffs": []
+        }
+    ],
+    "specialtySkill": {
+        "name": "Innocent Wanderer",
+        "description": "Neither wind nor rain can stop him.",
+        "dispatch": [],
+        "enhancement": [],
+        "stats": {
+            "command": 44,
+            "charm": 80,
+            "politics": 20
+        }
+    },
+    "memoryImprintFormation": {
+        "north": false,
+        "south": false,
+        "east": false,
+        "west": false
+    },
+    "memoryImprint": [
+        {
+            "rank": "d",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
+        },
+        {
+            "rank": "c",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
+        },
+        {
+            "rank": "b",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
+        },
+        {
+            "rank": "a",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
+        },
+        {
+            "rank": "s",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
+        },
+        {
+            "rank": "ss",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
+        },
+        {
+            "rank": "sss",
+            "status": {
+                "type": "",
+                "increase": 0
+            }
+        }
+    ],
+    "awakening": [
+        {
+            "rank": 1,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "": 0
+                },
+                {
+                    "atk": 20
+                },
+                {
+                    "hp": 60
+                }
+            ],
+            "resources": [
+                {
+                    "item": "light-rune",
+                    "qty": 8
+                }
+            ]
+        },
+        {
+            "rank": 2,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "": 0
+                },
+                {
+                    "atk": 20
+                },
+                {
+                    "hp": 60
+                }
+            ],
+            "resources": [
+                {
+                    "item": "light-rune",
+                    "qty": 12
+                },
+                {
+                    "item": "greater-light-rune",
+                    "qty": 2
+                }
+            ]
+        },
+        {
+            "rank": 3,
+            "skillUpgrade": true,
+            "statsIncrease": [
+                {
+                    "atk": 20
+                },
+                {
+                    "hp": 60
+                }
+            ],
+            "resources": [
+                {
+                    "item": "light-rune",
+                    "qty": 17
+                },
+                {
+                    "item": "greater-light-rune",
+                    "qty": 8
+                }
+            ]
+        },
+        {
+            "rank": 4,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "": 0
+                },
+                {
+                    "atk": 30
+                },
+                {
+                    "hp": 80
+                }
+            ],
+            "resources": [
+                {
+                    "item": "greater-light-rune",
+                    "qty": 8
+                },
+                {
+                    "item": "epic-light-rune",
+                    "qty": 2
+                }
+            ]
+        },
+        {
+            "rank": 5,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "": 0
+                },
+                {
+                    "atk": 30
+                },
+                {
+                    "hp": 80
+                }
+            ],
+            "resources": [
+                {
+                    "item": "epic-light-rune",
+                    "qty": 5
+                },
+                {
+                    "item": "special-alarm-loop",
+                    "qty": 12
+                }
+            ]
+        },
+        {
+            "rank": 6,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "": 0
+                },
+                {
+                    "atk": 30
+                },
+                {
+                    "hp": 80
+                }
+            ],
+            "resources": [
+                {
+                    "item": "epic-light-rune",
+                    "qty": 8
+                },
+                {
+                    "item": "the-heart-of-hypocrisy",
+                    "qty": 8
+                }
+            ]
+        }
+    ]
+}

--- a/src/hero/karin.json
+++ b/src/hero/karin.json
@@ -244,7 +244,9 @@
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_def_dn"]
+            "debuffs": [
+                "stic_def_dn"
+            ]
         },
         {
             "isPassive": false,
@@ -527,7 +529,7 @@
                 },
                 {
                     "item": "epic-frost-rune",
-                    "qty": 1
+                    "qty": 2
                 }
             ]
         },

--- a/src/hero/lots.json
+++ b/src/hero/lots.json
@@ -77,26 +77,61 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% effect chance",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "+15% effect chance",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "ring-of-glory",
+                            "qty": 3
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -104,18 +139,24 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "fused-nerve",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_att_dn"]
+            "debuffs": [
+                "stic_att_dn"
+            ]
         },
         {
             "isPassive": false,
@@ -130,26 +171,61 @@
             "enhancement": [
                 {
                     "description": "+5% healing",
-                    "resources": []
-                },
-                {
-                    "description": "+5% Combat Readiness",
-                    "resources": []
-                },
-                {
-                    "description": "+15% healing",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% Combat Readiness",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+15% healing",
+                    "resources": [
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% Combat Readiness",
+                    "resources": [
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -157,12 +233,16 @@
                     "description": "+10% Combat Readiness",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "fused-nerve",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -183,26 +263,44 @@
             "enhancement": [
                 {
                     "description": "+2% Combat Readiness",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+2% Combat Readiness",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
-                },
-                {
-                    "description": "+3% Combat Readiness",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "ring-of-glory",
+                            "qty": 1
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -210,17 +308,40 @@
                     "description": "+3% Combat Readiness",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "ring-of-glory",
+                            "qty": 3
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
+                        }
+                    ]
+                },
+                {
+                    "description": "+3% Combat Readiness",
+                    "resources": [
+                        {
+                            "item": "fused-nerve",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
             ],
-            "buffs": ["stic_heal"],
+            "buffs": [
+                "stic_heal"
+            ],
             "debuffs": []
         }
     ],
@@ -309,7 +430,7 @@
             ],
             "resources": [
                 {
-                    "item": "earth-rune",
+                    "item": "life-rune",
                     "qty": 8
                 }
             ]
@@ -330,11 +451,11 @@
             ],
             "resources": [
                 {
-                    "item": "earth-rune",
+                    "item": "life-rune",
                     "qty": 12
                 },
                 {
-                    "item": "greater-earth-rune",
+                    "item": "greater-life-rune",
                     "qty": 2
                 }
             ]
@@ -352,11 +473,11 @@
             ],
             "resources": [
                 {
-                    "item": "earth-rune",
+                    "item": "life-rune",
                     "qty": 17
                 },
                 {
-                    "item": "greater-earth-rune",
+                    "item": "greater-life-rune",
                     "qty": 8
                 }
             ]
@@ -377,11 +498,11 @@
             ],
             "resources": [
                 {
-                    "item": "greater-earth-rune",
+                    "item": "greater-life-rune",
                     "qty": 8
                 },
                 {
-                    "item": "epic-earth-rune",
+                    "item": "epic-life-rune",
                     "qty": 2
                 }
             ]
@@ -402,7 +523,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-earth-rune",
+                    "item": "epic-life-rune",
                     "qty": 5
                 },
                 {
@@ -427,7 +548,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-earth-rune",
+                    "item": "epic-life-rune",
                     "qty": 8
                 },
                 {

--- a/src/hero/maya.json
+++ b/src/hero/maya.json
@@ -185,7 +185,9 @@
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_stun"]
+            "debuffs": [
+                "stic_stun"
+            ]
         },
         {
             "isPassive": false,
@@ -294,7 +296,9 @@
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_stun"]
+            "debuffs": [
+                "stic_stun"
+            ]
         },
         {
             "isPassive": false,
@@ -359,15 +363,24 @@
                     ]
                 }
             ],
-            "buffs": ["stic_def_up"],
-            "debuffs": ["stic_att_dn", "stic_provoke"]
+            "buffs": [
+                "stic_def_up"
+            ],
+            "debuffs": [
+                "stic_att_dn",
+                "stic_provoke"
+            ]
         }
     ],
     "specialtySkill": {
         "name": "Strong Arms",
         "description": "Uses their buff arms to fight against injustice.",
-        "dispatch": ["[Security] Type"],
-        "enhancement": ["Reward Bonus +6%"],
+        "dispatch": [
+            "[Security] Type"
+        ],
+        "enhancement": [
+            "Reward Bonus +6%"
+        ],
         "stats": {
             "command": 50,
             "charm": 83,
@@ -431,7 +444,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "hp": "3%"
+                    "hp": 0.03
                 },
                 {
                     "atk": "20"
@@ -452,7 +465,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "eff": "3%"
+                    "eff": 0.03
                 },
                 {
                     "atk": "20"
@@ -515,7 +528,7 @@
                 },
                 {
                     "item": "epic-flame-rune",
-                    "qty": 1
+                    "qty": 2
                 }
             ]
         },
@@ -524,7 +537,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "hp": "6%"
+                    "hp": 0.06
                 },
                 {
                     "atk": "30"
@@ -549,7 +562,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "eff": "6%"
+                    "eff": 0.06
                 },
                 {
                     "atk": "30"

--- a/src/hero/mercedes.json
+++ b/src/hero/mercedes.json
@@ -77,26 +77,44 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 1
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -104,12 +122,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "black-curse-powder",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -130,26 +169,27 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
@@ -157,12 +197,50 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "black-curse-powder",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -183,26 +261,44 @@
             "enhancement": [
                 {
                     "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
-                },
-                {
-                    "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -210,12 +306,33 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
+                        }
+                    ]
+                },
+                {
+                    "description": "+15% damage dealt",
+                    "resources": [
+                        {
+                            "item": "black-curse-powder",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -309,7 +426,7 @@
             ],
             "resources": [
                 {
-                    "item": "fire-rune",
+                    "item": "flame-rune",
                     "qty": 8
                 }
             ]
@@ -330,11 +447,11 @@
             ],
             "resources": [
                 {
-                    "item": "fire-rune",
+                    "item": "flame-rune",
                     "qty": 12
                 },
                 {
-                    "item": "greater-fire-rune",
+                    "item": "greater-flame-rune",
                     "qty": 2
                 }
             ]
@@ -352,11 +469,11 @@
             ],
             "resources": [
                 {
-                    "item": "fire-rune",
+                    "item": "flame-rune",
                     "qty": 17
                 },
                 {
-                    "item": "greater-fire-rune",
+                    "item": "greater-flame-rune",
                     "qty": 8
                 }
             ]
@@ -377,11 +494,11 @@
             ],
             "resources": [
                 {
-                    "item": "greater-fire-rune",
+                    "item": "greater-flame-rune",
                     "qty": 8
                 },
                 {
-                    "item": "epic-fire-rune",
+                    "item": "epic-flame-rune",
                     "qty": 2
                 }
             ]
@@ -402,7 +519,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-fire-rune",
+                    "item": "epic-flame-rune",
                     "qty": 5
                 },
                 {
@@ -427,11 +544,11 @@
             ],
             "resources": [
                 {
-                    "item": "epic-fire-rune",
+                    "item": "epic-flame-rune",
                     "qty": 8
                 },
                 {
-                    "item": "black-cursed-powder",
+                    "item": "black-curse-powder",
                     "qty": 8
                 }
             ]

--- a/src/hero/purrgis.json
+++ b/src/hero/purrgis.json
@@ -77,26 +77,61 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% effect chance",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -104,12 +139,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "black-curse-powder",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -130,26 +169,61 @@
             "enhancement": [
                 {
                     "description": "+1% counterattack chance",
-                    "resources": []
-                },
-                {
-                    "description": "+2% counterattack chance",
-                    "resources": []
-                },
-                {
-                    "description": "+2% counterattack chance",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+2% counterattack chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+2% counterattack chance",
+                    "resources": [
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
+                },
+                {
+                    "description": "+2% counterattack chance",
+                    "resources": [
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -157,12 +231,16 @@
                     "description": "+3% counterattack chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "black-curse-powder",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -183,26 +261,44 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -210,12 +306,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "black-curse-powder",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -309,7 +426,7 @@
             ],
             "resources": [
                 {
-                    "item": "earth-rune",
+                    "item": "life-rune",
                     "qty": 8
                 }
             ]
@@ -330,11 +447,11 @@
             ],
             "resources": [
                 {
-                    "item": "earth-rune",
+                    "item": "life-rune",
                     "qty": 12
                 },
                 {
-                    "item": "greater-earth-rune",
+                    "item": "greater-life-rune",
                     "qty": 2
                 }
             ]
@@ -352,11 +469,11 @@
             ],
             "resources": [
                 {
-                    "item": "earth-rune",
+                    "item": "life-rune",
                     "qty": 17
                 },
                 {
-                    "item": "greater-earth-rune",
+                    "item": "greater-life-rune",
                     "qty": 8
                 }
             ]
@@ -377,11 +494,11 @@
             ],
             "resources": [
                 {
-                    "item": "greater-earth-rune",
+                    "item": "greater-life-rune",
                     "qty": 8
                 },
                 {
-                    "item": "epic-earth-rune",
+                    "item": "epic-life-rune",
                     "qty": 2
                 }
             ]
@@ -402,7 +519,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-earth-rune",
+                    "item": "epic-life-rune",
                     "qty": 5
                 },
                 {
@@ -427,11 +544,11 @@
             ],
             "resources": [
                 {
-                    "item": "epic-earth-rune",
+                    "item": "epic-life-rune",
                     "qty": 8
                 },
                 {
-                    "item": "black-cursed-powder",
+                    "item": "black-curse-powder",
                     "qty": 8
                 }
             ]

--- a/src/hero/rin.json
+++ b/src/hero/rin.json
@@ -77,26 +77,61 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "flame-of-soul",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "flame-of-soul",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 30000
                         }
                     ]
                 },
@@ -104,12 +139,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "flame-of-soul",
+                            "qty": 4
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
                         }
                     ]
                 },
@@ -117,12 +156,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "demon-blood-gem",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -143,26 +186,61 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% effect chance",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "flame-of-soul",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
                 },
                 {
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "flame-of-soul",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 30000
                         }
                     ]
                 },
@@ -170,12 +248,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "flame-of-soul",
+                            "qty": 4
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 40000
                         }
                     ]
                 },
@@ -183,12 +265,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "demon-blood-gem",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -209,15 +295,54 @@
             "enhancement": [
                 {
                     "description": "+15% healing",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "flame-of-soul",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 9000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "flame-of-soul",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
+                        }
+                    ]
                 },
                 {
                     "description": "+15% healing",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "demon-blood-gem",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 50000
+                        }
+                    ]
                 }
             ],
             "buffs": [],
@@ -309,7 +434,7 @@
             ],
             "resources": [
                 {
-                    "item": "earth-rune",
+                    "item": "life-rune",
                     "qty": 8
                 }
             ]
@@ -330,11 +455,11 @@
             ],
             "resources": [
                 {
-                    "item": "earth-rune",
+                    "item": "life-rune",
                     "qty": 12
                 },
                 {
-                    "item": "greater-earth-rune",
+                    "item": "greater-life-rune",
                     "qty": 2
                 }
             ]
@@ -352,11 +477,11 @@
             ],
             "resources": [
                 {
-                    "item": "earth-rune",
+                    "item": "life-rune",
                     "qty": 17
                 },
                 {
-                    "item": "greater-earth-rune",
+                    "item": "greater-life-rune",
                     "qty": 8
                 }
             ]
@@ -377,11 +502,11 @@
             ],
             "resources": [
                 {
-                    "item": "greater-earth-rune",
+                    "item": "greater-life-rune",
                     "qty": 8
                 },
                 {
-                    "item": "epic-earth-rune",
+                    "item": "epic-life-rune",
                     "qty": 2
                 }
             ]
@@ -402,7 +527,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-earth-rune",
+                    "item": "epic-life-rune",
                     "qty": 5
                 },
                 {
@@ -427,7 +552,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-earth-rune",
+                    "item": "epic-life-rune",
                     "qty": 8
                 },
                 {

--- a/src/hero/romann.json
+++ b/src/hero/romann.json
@@ -77,26 +77,44 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "+2% Combat Readiness",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "ring-of-glory",
+                            "qty": 1
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -104,12 +122,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "ring-of-glory",
+                            "qty": 3
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "fused-nerve",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -130,26 +169,61 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+2% Combat Readiness",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "+3% Combat Readiness",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "ring-of-glory",
+                            "qty": 3
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -157,12 +231,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "fused-nerve",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -183,26 +261,44 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
-                },
-                {
-                    "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "ring-of-glory",
+                            "qty": 1
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -210,12 +306,33 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "ring-of-glory",
+                            "qty": 3
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
+                        }
+                    ]
+                },
+                {
+                    "description": "+15% damage dealt",
+                    "resources": [
+                        {
+                            "item": "fused-nerve",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -309,7 +426,7 @@
             ],
             "resources": [
                 {
-                    "item": "ice-rune",
+                    "item": "frost-rune",
                     "qty": 8
                 }
             ]
@@ -330,11 +447,11 @@
             ],
             "resources": [
                 {
-                    "item": "ice-rune",
+                    "item": "frost-rune",
                     "qty": 12
                 },
                 {
-                    "item": "greater-ice-rune",
+                    "item": "greater-frost-rune",
                     "qty": 2
                 }
             ]
@@ -352,11 +469,11 @@
             ],
             "resources": [
                 {
-                    "item": "ice-rune",
+                    "item": "frost-rune",
                     "qty": 17
                 },
                 {
-                    "item": "greater-ice-rune",
+                    "item": "greater-frost-rune",
                     "qty": 8
                 }
             ]
@@ -377,11 +494,11 @@
             ],
             "resources": [
                 {
-                    "item": "greater-ice-rune",
+                    "item": "greater-frost-rune",
                     "qty": 8
                 },
                 {
-                    "item": "epic-ice-rune",
+                    "item": "epic-frost-rune",
                     "qty": 2
                 }
             ]
@@ -402,7 +519,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-ice-rune",
+                    "item": "epic-frost-rune",
                     "qty": 5
                 },
                 {
@@ -427,7 +544,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-ice-rune",
+                    "item": "epic-frost-rune",
                     "qty": 8
                 },
                 {

--- a/src/hero/rose.json
+++ b/src/hero/rose.json
@@ -77,26 +77,61 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% effect chance",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "mysterious-flash",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
                 },
                 {
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "mysterious-flash",
+                            "qty": 3
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -104,12 +139,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "reingar-student-id",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -130,26 +169,44 @@
             "enhancement": [
                 {
                     "description": "+2% Combat Readiness",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+2% Combat Readiness",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
-                },
-                {
-                    "description": "+3% Combat Readiness",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "mysterious-flash",
+                            "qty": 1
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -157,12 +214,33 @@
                     "description": "+3% Combat Readiness",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "mysterious-flash",
+                            "qty": 3
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
+                        }
+                    ]
+                },
+                {
+                    "description": "+3% Combat Readiness",
+                    "resources": [
+                        {
+                            "item": "reingar-student-id",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -183,26 +261,44 @@
             "enhancement": [
                 {
                     "description": "+2% Combat Readiness",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+2% Combat Readiness",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
-                },
-                {
-                    "description": "+3% Combat Readiness",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "mysterious-flash",
+                            "qty": 1
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -210,12 +306,33 @@
                     "description": "+3% Combat Readiness",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "mysterious-flash",
+                            "qty": 3
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
+                        }
+                    ]
+                },
+                {
+                    "description": "+3% Combat Readiness",
+                    "resources": [
+                        {
+                            "item": "reingar-student-id",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -309,7 +426,7 @@
             ],
             "resources": [
                 {
-                    "item": "ice-rune",
+                    "item": "frost-rune",
                     "qty": 8
                 }
             ]
@@ -330,11 +447,11 @@
             ],
             "resources": [
                 {
-                    "item": "ice-rune",
+                    "item": "frost-rune",
                     "qty": 12
                 },
                 {
-                    "item": "greater-ice-rune",
+                    "item": "greater-frost-rune",
                     "qty": 2
                 }
             ]
@@ -352,11 +469,11 @@
             ],
             "resources": [
                 {
-                    "item": "ice-rune",
+                    "item": "frost-rune",
                     "qty": 17
                 },
                 {
-                    "item": "greater-ice-rune",
+                    "item": "greater-frost-rune",
                     "qty": 8
                 }
             ]
@@ -377,11 +494,11 @@
             ],
             "resources": [
                 {
-                    "item": "greater-ice-rune",
+                    "item": "greater-frost-rune",
                     "qty": 8
                 },
                 {
-                    "item": "epic-ice-rune",
+                    "item": "epic-frost-rune",
                     "qty": 2
                 }
             ]
@@ -402,7 +519,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-ice-rune",
+                    "item": "epic-frost-rune",
                     "qty": 5
                 },
                 {
@@ -427,7 +544,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-ice-rune",
+                    "item": "epic-frost-rune",
                     "qty": 8
                 },
                 {

--- a/src/hero/schuri.json
+++ b/src/hero/schuri.json
@@ -77,26 +77,44 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% effect chance",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "twisted-fang",
+                            "qty": 1
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -104,12 +122,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "twisted-fang",
+                            "qty": 3
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "blazing-soul",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -130,26 +169,61 @@
             "enhancement": [
                 {
                     "description": "+1% Combat Readiness",
-                    "resources": []
-                },
-                {
-                    "description": "+2% Combat Readiness",
-                    "resources": []
-                },
-                {
-                    "description": "+2% Combat Readiness",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+2% Combat Readiness",
+                    "resources": [
+                        {
+                            "item": "twisted-fang",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
+                },
+                {
+                    "description": "+2% Combat Readiness",
+                    "resources": [
+                        {
+                            "item": "twisted-fang",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -157,12 +231,16 @@
                     "description": "+3% Combat Readiness",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "blazing-soul",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -183,26 +261,44 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "twisted-fang",
+                            "qty": 1
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -210,12 +306,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "twisted-fang",
+                            "qty": 3
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "blazing-soul",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -309,7 +426,7 @@
             ],
             "resources": [
                 {
-                    "item": "fire-rune",
+                    "item": "flame-rune",
                     "qty": 8
                 }
             ]
@@ -330,11 +447,11 @@
             ],
             "resources": [
                 {
-                    "item": "fire-rune",
+                    "item": "flame-rune",
                     "qty": 12
                 },
                 {
-                    "item": "greater-fire-rune",
+                    "item": "greater-flame-rune",
                     "qty": 2
                 }
             ]
@@ -352,11 +469,11 @@
             ],
             "resources": [
                 {
-                    "item": "fire-rune",
+                    "item": "flame-rune",
                     "qty": 17
                 },
                 {
-                    "item": "greater-fire-rune",
+                    "item": "greater-flame-rune",
                     "qty": 8
                 }
             ]
@@ -377,11 +494,11 @@
             ],
             "resources": [
                 {
-                    "item": "greater-fire-rune",
+                    "item": "greater-flame-rune",
                     "qty": 8
                 },
                 {
-                    "item": "epic-fire-rune",
+                    "item": "epic-flame-rune",
                     "qty": 2
                 }
             ]
@@ -402,7 +519,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-fire-rune",
+                    "item": "epic-flame-rune",
                     "qty": 5
                 },
                 {
@@ -427,7 +544,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-fire-rune",
+                    "item": "epic-flame-rune",
                     "qty": 8
                 },
                 {

--- a/src/hero/serila.json
+++ b/src/hero/serila.json
@@ -77,26 +77,61 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+1% Combat Readiness",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "leather-sheath",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
                 },
                 {
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "leather-sheath",
+                            "qty": 3
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -104,12 +139,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "fighter-medal",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -130,26 +169,61 @@
             "enhancement": [
                 {
                     "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% effect chance",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "leather-sheath",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "leather-sheath",
+                            "qty": 3
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -157,12 +231,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "fighter-medal",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -183,26 +261,61 @@
             "enhancement": [
                 {
                     "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% effect chance",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "leather-sheath",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "leather-sheath",
+                            "qty": 3
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -210,12 +323,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "fighter-medal",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -309,7 +426,7 @@
             ],
             "resources": [
                 {
-                    "item": "fire-rune",
+                    "item": "flame-rune",
                     "qty": 8
                 }
             ]
@@ -330,11 +447,11 @@
             ],
             "resources": [
                 {
-                    "item": "fire-rune",
+                    "item": "flame-rune",
                     "qty": 12
                 },
                 {
-                    "item": "greater-fire-rune",
+                    "item": "greater-flame-rune",
                     "qty": 2
                 }
             ]
@@ -352,11 +469,11 @@
             ],
             "resources": [
                 {
-                    "item": "fire-rune",
+                    "item": "flame-rune",
                     "qty": 17
                 },
                 {
-                    "item": "greater-fire-rune",
+                    "item": "greater-flame-rune",
                     "qty": 8
                 }
             ]
@@ -377,11 +494,11 @@
             ],
             "resources": [
                 {
-                    "item": "greater-fire-rune",
+                    "item": "greater-flame-rune",
                     "qty": 8
                 },
                 {
-                    "item": "epic-fire-rune",
+                    "item": "epic-flame-rune",
                     "qty": 2
                 }
             ]
@@ -402,7 +519,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-fire-rune",
+                    "item": "epic-flame-rune",
                     "qty": 5
                 },
                 {
@@ -427,7 +544,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-fire-rune",
+                    "item": "epic-flame-rune",
                     "qty": 8
                 },
                 {

--- a/src/hero/shadow-rose.json
+++ b/src/hero/shadow-rose.json
@@ -79,12 +79,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": "4000"
+                            "item": "molagora",
+                            "qty": 1
                         },
                         {
-                            "item": "molagora",
-                            "qty": "1"
+                            "item": "gold",
+                            "qty": 4000
                         }
                     ]
                 },
@@ -92,12 +92,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": "8000"
+                            "item": "molagora",
+                            "qty": 2
                         },
                         {
-                            "item": "molagora",
-                            "qty": "2"
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
@@ -105,16 +105,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": "17000"
+                            "item": "ring-of-glory",
+                            "qty": 1
                         },
                         {
                             "item": "molagora",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
-                            "item": "ring-of-glory",
-                            "qty": "1"
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -122,16 +122,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": "35000"
+                            "item": "ring-of-glory",
+                            "qty": 3
                         },
                         {
                             "item": "molagorago",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
-                            "item": "ring-of-glory",
-                            "qty": "3"
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -139,22 +139,25 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": "100000"
+                            "item": "fused-nerve",
+                            "qty": 2
                         },
                         {
                             "item": "molagorago",
-                            "qty": "2"
+                            "qty": 2
                         },
                         {
-                            "item": "fused-nerve",
-                            "qty": "2"
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_def_dn", "stic_heal_impossible"]
+            "debuffs": [
+                "stic_def_dn",
+                "stic_heal_impossible"
+            ]
         },
         {
             "isPassive": false,
@@ -171,12 +174,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": "4000"
+                            "item": "molagora",
+                            "qty": 1
                         },
                         {
-                            "item": "molagora",
-                            "qty": "1"
+                            "item": "gold",
+                            "qty": 4000
                         }
                     ]
                 },
@@ -184,69 +187,71 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
                             "item": "gold",
-                            "qty": "8000"
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 1
                         },
                         {
                             "item": "molagora",
-                            "qty": "2"
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": "17000"
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": "3"
-                        },
                         {
                             "item": "ring-of-glory",
-                            "qty": "1"
-                        }
-                    ]
-                },
-                {
-                    "description": "+10% damage dealt",
-                    "resources": [
-                        {
-                            "item": "gold",
-                            "qty": "35000"
+                            "qty": 3
                         },
                         {
                             "item": "molagorago",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
-                            "item": "ring-of-glory",
-                            "qty": "3"
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": "100000"
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": "2"
-                        },
                         {
                             "item": "fused-nerve",
-                            "qty": "2"
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_def_dn"]
+            "debuffs": [
+                "stic_def_dn"
+            ]
         },
         {
             "isPassive": false,
@@ -263,12 +268,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": "4000"
+                            "item": "molagora",
+                            "qty": 1
                         },
                         {
-                            "item": "molagora",
-                            "qty": "1"
+                            "item": "gold",
+                            "qty": 4000
                         }
                     ]
                 },
@@ -276,12 +281,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": "8000"
+                            "item": "molagora",
+                            "qty": 2
                         },
                         {
-                            "item": "molagora",
-                            "qty": "2"
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
@@ -289,16 +294,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": "17000"
+                            "item": "ring-of-glory",
+                            "qty": 1
                         },
                         {
                             "item": "molagora",
-                            "qty": "3"
+                            "qty": 3
                         },
                         {
-                            "item": "ring-of-glory",
-                            "qty": "1"
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -306,33 +311,33 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": "35000"
+                            "item": "ring-of-glory",
+                            "qty": 3
                         },
                         {
                             "item": "molagorago",
-                            "qty": "1"
+                            "qty": 1
                         },
                         {
-                            "item": "ring-of-glory",
-                            "qty": "3"
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
                 {
                     "description": "+15% damage dealt",
                     "resources": [
-                        {
-                            "item": "gold",
-                            "qty": "100000"
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": "2"
-                        },
                         {
                             "item": "fused-nerve",
-                            "qty": "2"
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -421,7 +426,7 @@
             "resources": [
                 {
                     "item": "dark-rune",
-                    "qty": "8"
+                    "qty": 8
                 }
             ]
         },
@@ -430,7 +435,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "chc": "3%"
+                    "chc": 0.03
                 },
                 {
                     "atk": "20"
@@ -442,11 +447,11 @@
             "resources": [
                 {
                     "item": "dark-rune",
-                    "qty": "12"
+                    "qty": 12
                 },
                 {
                     "item": "greater-dark-rune",
-                    "qty": "2"
+                    "qty": 2
                 }
             ]
         },
@@ -464,11 +469,11 @@
             "resources": [
                 {
                     "item": "dark-rune",
-                    "qty": "17"
+                    "qty": 17
                 },
                 {
-                    "item": "great-dark-rune",
-                    "qty": "8"
+                    "item": "greater-dark-rune",
+                    "qty": 8
                 }
             ]
         },
@@ -477,7 +482,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "atk": "6%"
+                    "atk": 0.06
                 },
                 {
                     "atk": "30"
@@ -489,11 +494,11 @@
             "resources": [
                 {
                     "item": "greater-dark-rune",
-                    "qty": "8"
+                    "qty": 8
                 },
                 {
                     "item": "epic-dark-rune",
-                    "qty": "1"
+                    "qty": 2
                 }
             ]
         },
@@ -514,11 +519,11 @@
             "resources": [
                 {
                     "item": "epic-dark-rune",
-                    "qty": "5"
+                    "qty": 5
                 },
                 {
                     "item": "small-sun-badge",
-                    "qty": "12"
+                    "qty": 12
                 }
             ]
         },
@@ -527,7 +532,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "chc": "6%"
+                    "chc": 0.06
                 },
                 {
                     "atk": "30"
@@ -539,11 +544,11 @@
             "resources": [
                 {
                     "item": "epic-dark-rune",
-                    "qty": "8"
+                    "qty": 8
                 },
                 {
                     "item": "fused-nerve",
-                    "qty": "8"
+                    "qty": 8
                 }
             ]
         }

--- a/src/hero/silk.json
+++ b/src/hero/silk.json
@@ -355,15 +355,23 @@
                     ]
                 }
             ],
-            "buffs": ["stic_speed_up"],
-            "debuffs": ["stic_speed_dn"]
+            "buffs": [
+                "stic_speed_up"
+            ],
+            "debuffs": [
+                "stic_speed_dn"
+            ]
         }
     ],
     "specialtySkill": {
         "name": "Wind Direction",
         "description": "Maybe it sounds like wind, but it's really a song sent from the forest.",
-        "dispatch": ["[Explore] Type"],
-        "enhancement": ["Reward Bonus +6%"],
+        "dispatch": [
+            "[Explore] Type"
+        ],
+        "enhancement": [
+            "Reward Bonus +6%"
+        ],
         "stats": {
             "command": 20,
             "charm": 87,
@@ -427,7 +435,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "atk": "3%"
+                    "atk": 0.03
                 },
                 {
                     "atk": "20"
@@ -448,7 +456,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "atk": "3%"
+                    "atk": 0.03
                 },
                 {
                     "atk": "20"
@@ -511,7 +519,7 @@
                 },
                 {
                     "item": "epic-life-rune",
-                    "qty": 1
+                    "qty": 2
                 }
             ]
         },
@@ -520,7 +528,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "atk": "6%"
+                    "atk": 0.06
                 },
                 {
                     "atk": "30"
@@ -545,7 +553,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "atk": "6%"
+                    "atk": 0.06
                 },
                 {
                     "atk": "30"

--- a/src/hero/surin.json
+++ b/src/hero/surin.json
@@ -77,26 +77,27 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
@@ -104,12 +105,50 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "ring-of-glory",
+                            "qty": 1
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "fused-nerve",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -130,26 +169,61 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": []
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 3
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -157,12 +231,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "fused-nerve",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -183,26 +261,44 @@
             "enhancement": [
                 {
                     "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
-                },
-                {
-                    "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "ring-of-glory",
+                            "qty": 1
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -210,12 +306,33 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "ring-of-glory",
+                            "qty": 3
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
+                        }
+                    ]
+                },
+                {
+                    "description": "+15% damage dealt",
+                    "resources": [
+                        {
+                            "item": "fused-nerve",
+                            "qty": 2
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -309,7 +426,7 @@
             ],
             "resources": [
                 {
-                    "item": "fire-rune",
+                    "item": "flame-rune",
                     "qty": 8
                 }
             ]
@@ -330,11 +447,11 @@
             ],
             "resources": [
                 {
-                    "item": "fire-rune",
+                    "item": "flame-rune",
                     "qty": 12
                 },
                 {
-                    "item": "greater-fire-rune",
+                    "item": "greater-flame-rune",
                     "qty": 2
                 }
             ]
@@ -352,11 +469,11 @@
             ],
             "resources": [
                 {
-                    "item": "fire-rune",
+                    "item": "flame-rune",
                     "qty": 17
                 },
                 {
-                    "item": "greater-fire-rune",
+                    "item": "greater-flame-rune",
                     "qty": 8
                 }
             ]
@@ -377,11 +494,11 @@
             ],
             "resources": [
                 {
-                    "item": "greater-fire-rune",
+                    "item": "greater-flame-rune",
                     "qty": 8
                 },
                 {
-                    "item": "epic-fire-rune",
+                    "item": "epic-flame-rune",
                     "qty": 2
                 }
             ]
@@ -402,7 +519,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-fire-rune",
+                    "item": "epic-flame-rune",
                     "qty": 5
                 },
                 {
@@ -427,7 +544,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-fire-rune",
+                    "item": "epic-flame-rune",
                     "qty": 8
                 },
                 {

--- a/src/hero/wanderer-silk.json
+++ b/src/hero/wanderer-silk.json
@@ -156,7 +156,9 @@
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_blood"]
+            "debuffs": [
+                "stic_blood"
+            ]
         },
         {
             "isPassive": false,
@@ -340,14 +342,21 @@
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_heal_impossible", "stic_silence"]
+            "debuffs": [
+                "stic_heal_impossible",
+                "stic_silence"
+            ]
         }
     ],
     "specialtySkill": {
         "name": "Calm Before the Storm",
         "description": "She keeps on her toes, knowing danger lurks around every corner.",
-        "dispatch": ["[Battle] Type"],
-        "enhancement": ["Reward Bonus +6%"],
+        "dispatch": [
+            "[Battle] Type"
+        ],
+        "enhancement": [
+            "Reward Bonus +6%"
+        ],
         "stats": {
             "command": 15,
             "charm": 85,
@@ -432,7 +441,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "eff": "3%"
+                    "eff": 0.03
                 },
                 {
                     "atk": "20"
@@ -479,7 +488,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "eff": "6%"
+                    "eff": 0.06
                 },
                 {
                     "atk": "30"
@@ -495,7 +504,7 @@
                 },
                 {
                     "item": "epic-light-rune",
-                    "qty": 1
+                    "qty": 2
                 }
             ]
         },
@@ -529,7 +538,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "eff": "6%"
+                    "eff": 0.06
                 },
                 {
                     "atk": "30"

--- a/src/hero/watcher-schuri.json
+++ b/src/hero/watcher-schuri.json
@@ -85,12 +85,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 4000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
                         }
                     ]
                 },
@@ -98,12 +98,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 8000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
@@ -111,16 +111,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 17000
-                        },
-                        {
                             "item": "sharp-spearhead",
                             "qty": 1
                         },
                         {
                             "item": "molagora",
                             "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -128,16 +128,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 35000
-                        },
-                        {
                             "item": "sharp-spearhead",
                             "qty": 3
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -145,22 +145,24 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 100000
-                        },
-                        {
-                            "item": "black-powder-curse",
+                            "item": "black-curse-powder",
                             "qty": 2
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
             ],
             "buffs": [],
-            "debuffs": ["stic_sign"]
+            "debuffs": [
+                "stic_sign"
+            ]
         },
         {
             "isPassive": false,
@@ -176,12 +178,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 4000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
                         }
                     ]
                 },
@@ -189,12 +191,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 8000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
@@ -202,16 +204,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 17000
-                        },
-                        {
                             "item": "sharp-spearhead",
                             "qty": 1
                         },
                         {
                             "item": "molagora",
                             "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -219,16 +221,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 35000
-                        },
-                        {
                             "item": "sharp-spearhead",
                             "qty": 3
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -236,21 +238,23 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 100000
-                        },
-                        {
-                            "item": "black-powder-curse",
+                            "item": "black-curse-powder",
                             "qty": 2
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
             ],
-            "buffs": ["stic_spd_up"],
+            "buffs": [
+                "stic_spd_up"
+            ],
             "debuffs": []
         },
         {
@@ -267,12 +271,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 4000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
                         }
                     ]
                 },
@@ -280,12 +284,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 8000
-                        },
-                        {
                             "item": "molagora",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
                         }
                     ]
                 },
@@ -293,16 +297,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 17000
-                        },
-                        {
                             "item": "sharp-spearhead",
                             "qty": 1
                         },
                         {
                             "item": "molagora",
                             "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -310,16 +314,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 35000
-                        },
-                        {
                             "item": "sharp-spearhead",
                             "qty": 3
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 35000
                         }
                     ]
                 },
@@ -327,16 +331,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 100000
-                        },
-                        {
-                            "item": "black-powder-curse",
+                            "item": "black-curse-powder",
                             "qty": 2
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -348,8 +352,12 @@
     "specialtySkill": {
         "name": "Hypervision",
         "description": "He can see through everything.",
-        "dispatch": ["[Hidden Clue] Attribute"],
-        "enhancement": ["Reward Bonus +10%"],
+        "dispatch": [
+            "[Hidden Clue] Attribute"
+        ],
+        "enhancement": [
+            "Reward Bonus +10%"
+        ],
         "stats": {
             "command": 75,
             "charm": 73,
@@ -413,7 +421,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "atk": "3%"
+                    "atk": 0.03
                 },
                 {
                     "atk": 20
@@ -434,7 +442,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "chc": "3%"
+                    "chc": 0.03
                 },
                 {
                     "atk": 20
@@ -497,7 +505,7 @@
                 },
                 {
                     "item": "epic-light-rune",
-                    "qty": 1
+                    "qty": 2
                 }
             ]
         },
@@ -506,7 +514,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "efr": "6%"
+                    "efr": 0.06
                 },
                 {
                     "atk": 30
@@ -531,7 +539,7 @@
             "skillUpgrade": false,
             "statsIncrease": [
                 {
-                    "eff": "6%"
+                    "eff": 0.06
                 },
                 {
                     "atk": 30

--- a/src/hero/zerato.json
+++ b/src/hero/zerato.json
@@ -77,26 +77,65 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "path-power-loop",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 4
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 21000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% effect chance",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "path-power-loop",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 7
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 33000
+                        }
+                    ]
                 },
                 {
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "nightmare-mask",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 80000
                         }
                     ]
                 }
@@ -117,26 +156,65 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "path-power-loop",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 4
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 21000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "path-power-loop",
+                            "qty": 1
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 7
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 33000
+                        }
+                    ]
                 },
                 {
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "nightmare-mask",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 80000
                         }
                     ]
                 }
@@ -157,26 +235,57 @@
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        }
+                    ]
                 },
                 {
                     "description": "+5% damage dealt",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 8000
+                        }
+                    ]
                 },
                 {
                     "description": "+10% effect chance",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 12000
+                        }
+                    ]
                 },
                 {
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "path-power-loop",
+                            "qty": 1
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 17000
                         }
                     ]
                 },
@@ -184,12 +293,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "path-power-loop",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 30000
                         }
                     ]
                 },
@@ -197,12 +310,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "path-power-loop",
+                            "qty": 5
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 45000
                         }
                     ]
                 },
@@ -210,12 +327,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "gold",
-                            "qty": 0
+                            "item": "nightmare-mask",
+                            "qty": 2
                         },
                         {
-                            "item": "",
-                            "qty": 0
+                            "item": "molagorago",
+                            "qty": 2
+                        },
+                        {
+                            "item": "gold",
+                            "qty": 100000
                         }
                     ]
                 }
@@ -309,7 +430,7 @@
             ],
             "resources": [
                 {
-                    "item": "ice-rune",
+                    "item": "frost-rune",
                     "qty": 8
                 }
             ]
@@ -330,11 +451,11 @@
             ],
             "resources": [
                 {
-                    "item": "ice-rune",
+                    "item": "frost-rune",
                     "qty": 12
                 },
                 {
-                    "item": "greater-ice-rune",
+                    "item": "greater-frost-rune",
                     "qty": 2
                 }
             ]
@@ -352,11 +473,11 @@
             ],
             "resources": [
                 {
-                    "item": "ice-rune",
+                    "item": "frost-rune",
                     "qty": 17
                 },
                 {
-                    "item": "greater-ice-rune",
+                    "item": "greater-frost-rune",
                     "qty": 8
                 }
             ]
@@ -377,11 +498,11 @@
             ],
             "resources": [
                 {
-                    "item": "greater-ice-rune",
+                    "item": "greater-frost-rune",
                     "qty": 8
                 },
                 {
-                    "item": "epic-ice-rune",
+                    "item": "epic-frost-rune",
                     "qty": 2
                 }
             ]
@@ -402,7 +523,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-ice-rune",
+                    "item": "epic-frost-rune",
                     "qty": 5
                 },
                 {
@@ -427,7 +548,7 @@
             ],
             "resources": [
                 {
-                    "item": "epic-ice-rune",
+                    "item": "epic-frost-rune",
                     "qty": 8
                 },
                 {


### PR DESCRIPTION
Just like the 5* PR, this just imports and re-exports all the 4* heroes. This mainly just syncs the format but does fix a few issues that were missed.

The only oddities this time are that ML Cidd and Aither were missed(/assigned to someone no longer helping in wiki) in initial basic description pass. Basic descriptions were made for them.