### PR TITLE
Rename Purple Talisman after patch

### DIFF
--- a/src/artifact/purple-talisman.json
+++ b/src/artifact/purple-talisman.json
@@ -1,5 +1,5 @@
 {
-    "name": "Violet Talisman",
+    "name": "Purple Talisman",
     "rarity": 5,
     "exclusive": ["thief"],
     "loreDescription": [


### PR DESCRIPTION
Maintenance changed artifact name from violet to purple.