### PR TITLE
Fixed skill enhancement item order and added memoryImprintAttribute 

### DIFF
--- a/src/hero/achates.json
+++ b/src/hero/achates.json
@@ -108,12 +108,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -121,12 +121,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -134,16 +134,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "ring-of-glory",
+                            "qty": 1
                         }
                     ]
                 },
@@ -151,16 +151,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -168,16 +168,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -220,42 +220,42 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% healing",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+5% healing",
                     "resources": [
-                        {
-                            "item": "ring-of-glory",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 17000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 1
                         }
                     ]
                 },
@@ -263,16 +263,16 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -280,16 +280,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -332,12 +332,12 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -345,12 +345,12 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -358,33 +358,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "ring-of-glory",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% healing",
                     "resources": [
-                        {
-                            "item": "ring-of-glory",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -392,16 +392,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -475,6 +475,7 @@
         "east": true,
         "west": false
     },
+    "memoryImprintAttribute": "def",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/adlay.json
+++ b/src/hero/adlay.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "archers-vision",
+                            "qty": 3
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "archers-vision",
+                            "qty": 4
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "archers-vision",
+                            "qty": 5
                         }
                     ]
                 }
@@ -216,12 +216,12 @@
                     "description": "+0.5% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -229,12 +229,12 @@
                     "description": "+0.5% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -242,16 +242,16 @@
                     "description": "+0.5% Combat Readiness",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "archers-vision",
+                            "qty": 3
                         }
                     ]
                 },
@@ -259,16 +259,16 @@
                     "description": "+0.5% Combat Readiness",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "archers-vision",
+                            "qty": 4
                         }
                     ]
                 },
@@ -276,16 +276,16 @@
                     "description": "+1% Combat Readiness",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "archers-vision",
+                            "qty": 5
                         }
                     ]
                 }
@@ -326,12 +326,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -339,12 +339,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -352,16 +352,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "archers-vision",
+                            "qty": 3
                         }
                     ]
                 },
@@ -369,16 +369,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "archers-vision",
+                            "qty": 4
                         }
                     ]
                 },
@@ -386,16 +386,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "archers-vision",
+                            "qty": 5
                         }
                     ]
                 }
@@ -469,6 +469,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/aither.json
+++ b/src/hero/aither.json
@@ -116,29 +116,29 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% effect chance",
                     "resources": [
-                        {
-                            "item": "mysterious-flash",
-                            "qty": 2
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 18000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "mysterious-flash",
+                            "qty": 2
                         }
                     ]
                 },
@@ -146,16 +146,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 },
@@ -163,16 +163,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "mysterious-flash",
+                            "qty": 4
                         }
                     ]
                 }
@@ -215,12 +215,12 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -228,33 +228,33 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "mysterious-flash",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% healing",
                     "resources": [
-                        {
-                            "item": "mysterious-flash",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 23000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 },
@@ -262,16 +262,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "mysterious-flash",
+                            "qty": 4
                         }
                     ]
                 }
@@ -312,12 +312,12 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -325,42 +325,42 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% healing",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+5% healing",
                     "resources": [
-                        {
-                            "item": "mysterious-flash",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 23000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 },
@@ -368,16 +368,16 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 28000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 28000
+                            "item": "mysterious-flash",
+                            "qty": 4
                         }
                     ]
                 },
@@ -385,16 +385,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "mysterious-flash",
+                            "qty": 5
                         }
                     ]
                 },
@@ -402,16 +402,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "mysterious-flash",
+                            "qty": 6
                         }
                     ]
                 }
@@ -487,6 +487,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/alexa.json
+++ b/src/hero/alexa.json
@@ -108,16 +108,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 14000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 14000
+                            "item": "twisted-fang",
+                            "qty": 2
                         }
                     ]
                 },
@@ -125,16 +125,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -142,16 +142,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 }
@@ -192,12 +192,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -205,12 +205,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -218,16 +218,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "twisted-fang",
+                            "qty": 1
                         }
                     ]
                 },
@@ -235,16 +235,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "twisted-fang",
+                            "qty": 2
                         }
                     ]
                 },
@@ -252,16 +252,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 },
@@ -269,16 +269,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "twisted-fang",
+                            "qty": 6
                         }
                     ]
                 }
@@ -321,12 +321,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -334,12 +334,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -347,33 +347,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "twisted-fang",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "twisted-fang",
-                            "qty": 2
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 18000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "twisted-fang",
+                            "qty": 2
                         }
                     ]
                 },
@@ -381,16 +381,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 },
@@ -398,16 +398,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "twisted-fang",
+                            "qty": 6
                         }
                     ]
                 }
@@ -481,6 +481,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/angelic-montmorancy.json
+++ b/src/hero/angelic-montmorancy.json
@@ -100,12 +100,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -113,12 +113,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -126,16 +126,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "strange-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -143,16 +143,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "strange-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "strange-jelly",
+                            "qty": 5
                         }
                     ]
                 }
@@ -212,12 +212,12 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -225,12 +225,12 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -238,16 +238,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "strange-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -255,16 +255,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "strange-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -272,16 +272,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "strange-jelly",
+                            "qty": 5
                         }
                     ]
                 }
@@ -322,12 +322,12 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -335,12 +335,12 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -348,16 +348,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "strange-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -365,16 +365,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "strange-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -382,16 +382,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "strange-jelly",
+                            "qty": 5
                         }
                     ]
                 }
@@ -467,6 +467,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "def",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/angelica.json
+++ b/src/hero/angelica.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -130,33 +130,33 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "baby-mouse-insignia",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "baby-mouse-insignia",
+                            "qty": 3
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
                         }
                     ]
                 }
@@ -216,12 +216,12 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -229,46 +229,29 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% healing",
                     "resources": [
-                        {
-                            "item": "baby-mouse-insignia",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 17000
-                        }
-                    ]
-                },
-                {
-                    "description": "+10% healing",
-                    "resources": [
-                        {
-                            "item": "baby-mouse-insignia",
-                            "qty": 3
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
                         }
                     ]
                 },
@@ -276,16 +259,33 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "baby-mouse-insignia",
+                            "qty": 3
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% healing",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
                         }
                     ]
                 }
@@ -326,12 +326,12 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -339,12 +339,12 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -352,33 +352,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% healing",
                     "resources": [
-                        {
-                            "item": "baby-mouse-insignia",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "baby-mouse-insignia",
+                            "qty": 3
                         }
                     ]
                 },
@@ -386,16 +386,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
                         }
                     ]
                 }
@@ -523,6 +523,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "efr",
     "awakening": [
         {
             "rank": 1,

--- a/src/hero/aramintha.json
+++ b/src/hero/aramintha.json
@@ -120,12 +120,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -133,16 +133,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -150,16 +150,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 49000
                         },
                         {
                             "item": "molagora",
                             "qty": 6
                         },
                         {
-                            "item": "gold",
-                            "qty": 49000
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 },
@@ -167,16 +167,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -219,12 +219,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -232,16 +232,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -249,16 +249,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 49000
                         },
                         {
                             "item": "molagora",
                             "qty": 6
                         },
                         {
-                            "item": "gold",
-                            "qty": 49000
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 },
@@ -266,16 +266,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -321,12 +321,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -334,12 +334,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -347,12 +347,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -360,16 +360,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -377,33 +377,33 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "ring-of-glory",
+                            "qty": 4
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "ring-of-glory",
-                            "qty": 7
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 55000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 7
                         }
                     ]
                 },
@@ -411,16 +411,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 110000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 110000
+                            "item": "fused-nerve",
+                            "qty": 3
                         }
                     ]
                 }
@@ -496,6 +496,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/arbiter-vildred.json
+++ b/src/hero/arbiter-vildred.json
@@ -120,12 +120,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -133,12 +133,12 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -146,16 +146,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "twisted-fang",
+                            "qty": 2
                         }
                     ]
                 },
@@ -163,33 +163,33 @@
                     "description": "+3% Combat Readiness",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 36000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 36000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "twisted-fang",
-                            "qty": 5
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 45000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 },
@@ -197,16 +197,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -247,16 +247,16 @@
                     "description": "+10% Health recovered",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 19000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 19000
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -264,16 +264,16 @@
                     "description": "+10% Health recovered",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 },
@@ -281,16 +281,16 @@
                     "description": "+10% Health recovered",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 130000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 130000
+                            "item": "blazing-soul",
+                            "qty": 3
                         }
                     ]
                 }
@@ -331,25 +331,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -357,16 +357,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "twisted-fang",
+                            "qty": 2
                         }
                     ]
                 },
@@ -374,33 +374,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 36000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 36000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "twisted-fang",
-                            "qty": 5
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 45000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 },
@@ -408,16 +408,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -493,6 +493,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "eff",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/armin.json
+++ b/src/hero/armin.json
@@ -108,12 +108,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -121,25 +121,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% effect chance",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "slime-jelly",
+                            "qty": 1
                         }
                     ]
                 },
@@ -164,33 +164,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "slime-jelly",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "slime-jelly",
-                            "qty": 5
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 45000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "slime-jelly",
+                            "qty": 5
                         }
                     ]
                 },
@@ -198,16 +198,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "dragons-wrath",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "dragons-wrath",
+                            "qty": 2
                         }
                     ]
                 }
@@ -259,25 +259,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -285,16 +285,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "slime-jelly",
+                            "qty": 1
                         }
                     ]
                 },
@@ -302,16 +302,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "slime-jelly",
+                            "qty": 2
                         }
                     ]
                 },
@@ -319,16 +319,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "slime-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -336,16 +336,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "dragons-wrath",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "dragons-wrath",
+                            "qty": 2
                         }
                     ]
                 }
@@ -400,16 +400,16 @@
                     "description": "Acquire +1 Soul",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "slime-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -417,16 +417,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "dragons-wrath",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "dragons-wrath",
+                            "qty": 1
                         }
                     ]
                 }
@@ -502,6 +502,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/arowell.json
+++ b/src/hero/arowell.json
@@ -100,12 +100,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -113,12 +113,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -126,16 +126,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "mysterious-flash",
+                            "qty": 1
                         }
                     ]
                 },
@@ -143,16 +143,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "mysterious-flash",
+                            "qty": 2
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "mysterious-flash",
+                            "qty": 4
                         }
                     ]
                 },
@@ -177,16 +177,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "mysterious-flash",
+                            "qty": 6
                         }
                     ]
                 }
@@ -237,16 +237,16 @@
                     "description": "+2% barrier strength",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 14000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 14000
+                            "item": "mysterious-flash",
+                            "qty": 2
                         }
                     ]
                 },
@@ -254,16 +254,16 @@
                     "description": "+2% barrier strength",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 },
@@ -271,16 +271,16 @@
                     "description": "+2% barrier strength",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "mysterious-flash",
+                            "qty": 5
                         }
                     ]
                 }
@@ -323,12 +323,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -336,12 +336,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -349,16 +349,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "mysterious-flash",
+                            "qty": 1
                         }
                     ]
                 },
@@ -366,16 +366,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "mysterious-flash",
+                            "qty": 2
                         }
                     ]
                 },
@@ -383,16 +383,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "mysterious-flash",
+                            "qty": 4
                         }
                     ]
                 },
@@ -400,16 +400,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "mysterious-flash",
+                            "qty": 6
                         }
                     ]
                 }
@@ -495,6 +495,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/assassin-cartuja.json
+++ b/src/hero/assassin-cartuja.json
@@ -96,12 +96,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -109,12 +109,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -122,16 +122,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
@@ -139,16 +139,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -156,16 +156,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -208,59 +208,42 @@
                     "description": "+1% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+1% Combat Readiness",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+1% Combat Readiness",
                     "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 17000
-                        }
-                    ]
-                },
-                {
-                    "description": "+1% Combat Readiness",
-                    "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 3
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
@@ -268,16 +251,33 @@
                     "description": "+1% Combat Readiness",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 3
+                        }
+                    ]
+                },
+                {
+                    "description": "+1% Combat Readiness",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -318,12 +318,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -331,12 +331,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -344,16 +344,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
@@ -361,16 +361,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -378,16 +378,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -464,6 +464,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "def",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/assassin-cidd.json
+++ b/src/hero/assassin-cidd.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "leather-sheath",
+                            "qty": 1
                         }
                     ]
                 },
@@ -147,33 +147,33 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "leather-sheath",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "leather-sheath",
-                            "qty": 4
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 32000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "leather-sheath",
+                            "qty": 4
                         }
                     ]
                 },
@@ -181,16 +181,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "fighter-medal",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fighter-medal",
+                            "qty": 2
                         }
                     ]
                 }
@@ -243,16 +243,16 @@
                     "description": "+3% Combat Readiness",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 9000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 9000
+                            "item": "leather-sheath",
+                            "qty": 1
                         }
                     ]
                 },
@@ -260,16 +260,16 @@
                     "description": "+5% Combat Readiness",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 31000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 31000
+                            "item": "leather-sheath",
+                            "qty": 3
                         }
                     ]
                 },
@@ -277,16 +277,16 @@
                     "description": "+7% Combat Readiness",
                     "resources": [
                         {
-                            "item": "fighter-medal",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "fighter-medal",
+                            "qty": 1
                         }
                     ]
                 }
@@ -329,12 +329,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -342,12 +342,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -355,16 +355,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "leather-sheath",
+                            "qty": 1
                         }
                     ]
                 },
@@ -372,33 +372,33 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "leather-sheath",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "leather-sheath",
-                            "qty": 4
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 32000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "leather-sheath",
+                            "qty": 4
                         }
                     ]
                 },
@@ -406,16 +406,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "fighter-medal",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fighter-medal",
+                            "qty": 2
                         }
                     ]
                 }
@@ -511,6 +511,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/assassin-coli.json
+++ b/src/hero/assassin-coli.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,16 +117,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "shiny-enchantment",
+                            "qty": 1
                         }
                     ]
                 },
@@ -134,16 +134,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 21000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 21000
+                            "item": "shiny-enchantment",
+                            "qty": 1
                         }
                     ]
                 },
@@ -151,16 +151,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "horn-of-desire",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "horn-of-desire",
+                            "qty": 2
                         }
                     ]
                 }
@@ -211,12 +211,12 @@
                     "description": "+5% trigger chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -224,16 +224,16 @@
                     "description": "+5% trigger chance",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "shiny-enchantment",
+                            "qty": 1
                         }
                     ]
                 },
@@ -241,16 +241,16 @@
                     "description": "+5% trigger chance",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 21000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 21000
+                            "item": "shiny-enchantment",
+                            "qty": 1
                         }
                     ]
                 },
@@ -258,16 +258,16 @@
                     "description": "+5% trigger chance",
                     "resources": [
                         {
-                            "item": "horn-of-desire",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "horn-of-desire",
+                            "qty": 2
                         }
                     ]
                 }
@@ -311,12 +311,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -324,25 +324,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -350,16 +350,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "shiny-enchantment",
+                            "qty": 1
                         }
                     ]
                 },
@@ -367,16 +367,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "shiny-enchantment",
+                            "qty": 2
                         }
                     ]
                 },
@@ -384,16 +384,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "shiny-enchantment",
+                            "qty": 5
                         }
                     ]
                 },
@@ -401,16 +401,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "horn-of-desire",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "horn-of-desire",
+                            "qty": 2
                         }
                     ]
                 }
@@ -497,6 +497,7 @@
         "east": true,
         "west": false
     },
+    "memoryImprintAttribute": "chc",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/auxiliary-lots.json
+++ b/src/hero/auxiliary-lots.json
@@ -100,25 +100,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -126,33 +126,33 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "strange-jelly",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "strange-jelly",
-                            "qty": 2
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 22000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "strange-jelly",
+                            "qty": 2
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "strange-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -177,16 +177,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "ancient-creature-nucleus",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "ancient-creature-nucleus",
+                            "qty": 2
                         }
                     ]
                 }
@@ -229,16 +229,16 @@
                     "description": "+5% Combat Readiness",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 9000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 9000
+                            "item": "strange-jelly",
+                            "qty": 1
                         }
                     ]
                 },
@@ -246,16 +246,16 @@
                     "description": "+5% Combat Readiness",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 31000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 31000
+                            "item": "strange-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -263,16 +263,16 @@
                     "description": "+10% Combat Readiness",
                     "resources": [
                         {
-                            "item": "ancient-creature-nucleus",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "ancient-creature-nucleus",
+                            "qty": 1
                         }
                     ]
                 }
@@ -315,12 +315,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -328,12 +328,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -341,16 +341,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "strange-jelly",
+                            "qty": 1
                         }
                     ]
                 },
@@ -358,16 +358,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "strange-jelly",
+                            "qty": 2
                         }
                     ]
                 },
@@ -375,16 +375,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "strange-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -392,16 +392,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "ancient-creature-nucleus",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "ancient-creature-nucleus",
+                            "qty": 2
                         }
                     ]
                 }
@@ -477,6 +477,7 @@
         "east": true,
         "west": false
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/azalea.json
+++ b/src/hero/azalea.json
@@ -104,12 +104,12 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "sharp-spearhead",
+                            "qty": 4
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "sharp-spearhead",
+                            "qty": 5
                         }
                     ]
                 }
@@ -214,12 +214,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -227,12 +227,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -240,16 +240,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -257,16 +257,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "sharp-spearhead",
+                            "qty": 4
                         }
                     ]
                 },
@@ -274,16 +274,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "sharp-spearhead",
+                            "qty": 5
                         }
                     ]
                 }
@@ -327,12 +327,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -340,12 +340,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -353,16 +353,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -370,16 +370,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "sharp-spearhead",
+                            "qty": 4
                         }
                     ]
                 },
@@ -387,16 +387,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "sharp-spearhead",
+                            "qty": 5
                         }
                     ]
                 }
@@ -472,6 +472,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/baal-sezan.json
+++ b/src/hero/baal-sezan.json
@@ -104,16 +104,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 19000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 19000
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -121,16 +121,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 },
@@ -138,16 +138,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 130000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 130000
+                            "item": "fused-nerve",
+                            "qty": 3
                         }
                     ]
                 }
@@ -190,12 +190,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -203,12 +203,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -216,16 +216,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "ring-of-glory",
+                            "qty": 2
                         }
                     ]
                 },
@@ -233,33 +233,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 36000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 36000
+                            "item": "ring-of-glory",
+                            "qty": 4
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "ring-of-glory",
-                            "qty": 5
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 45000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 },
@@ -267,16 +267,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -317,12 +317,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -330,12 +330,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -343,16 +343,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "ring-of-glory",
+                            "qty": 2
                         }
                     ]
                 },
@@ -360,16 +360,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 36000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 36000
+                            "item": "ring-of-glory",
+                            "qty": 4
                         }
                     ]
                 },
@@ -377,16 +377,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 },
@@ -394,16 +394,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -481,6 +481,7 @@
         "east": true,
         "west": false
     },
+    "memoryImprintAttribute": "eff",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/baiken.json
+++ b/src/hero/baiken.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "sharp-spearhead",
+                            "qty": 5
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "sharp-spearhead",
+                            "qty": 7
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -216,12 +216,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -229,12 +229,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -242,16 +242,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "sharp-spearhead",
+                            "qty": 5
                         }
                     ]
                 },
@@ -259,16 +259,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "sharp-spearhead",
+                            "qty": 7
                         }
                     ]
                 },
@@ -276,16 +276,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -328,12 +328,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -341,12 +341,12 @@
                     "description": "+5% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -354,16 +354,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "sharp-spearhead",
+                            "qty": 5
                         }
                     ]
                 },
@@ -371,16 +371,16 @@
                     "description": "+5% Combat Readiness",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "sharp-spearhead",
+                            "qty": 7
                         }
                     ]
                 },
@@ -388,16 +388,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -471,6 +471,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/basar.json
+++ b/src/hero/basar.json
@@ -100,12 +100,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -113,12 +113,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -126,16 +126,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "leather-sheath",
+                            "qty": 5
                         }
                     ]
                 },
@@ -143,16 +143,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "leather-sheath",
+                            "qty": 7
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "fighter-medal",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "fighter-medal",
+                            "qty": 2
                         }
                     ]
                 }
@@ -210,12 +210,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -223,12 +223,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -236,16 +236,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "leather-sheath",
+                            "qty": 5
                         }
                     ]
                 },
@@ -253,16 +253,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "leather-sheath",
+                            "qty": 7
                         }
                     ]
                 },
@@ -270,16 +270,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "fighter-medal",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "fighter-medal",
+                            "qty": 2
                         }
                     ]
                 }
@@ -322,12 +322,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -335,12 +335,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -348,16 +348,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "leather-sheath",
+                            "qty": 5
                         }
                     ]
                 },
@@ -365,16 +365,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "leather-sheath",
+                            "qty": 7
                         }
                     ]
                 },
@@ -382,16 +382,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "fighter-medal",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "fighter-medal",
+                            "qty": 2
                         }
                     ]
                 }
@@ -467,6 +467,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "eff",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/bask.json
+++ b/src/hero/bask.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,29 +117,29 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 13000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "sharp-spearhead",
+                            "qty": 2
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "sharp-spearhead",
+                            "qty": 4
                         }
                     ]
                 },
@@ -181,16 +181,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "sharp-spearhead",
+                            "qty": 6
                         }
                     ]
                 }
@@ -243,12 +243,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -256,12 +256,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -269,12 +269,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -282,16 +282,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -299,16 +299,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 28000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 28000
+                            "item": "sharp-spearhead",
+                            "qty": 4
                         }
                     ]
                 },
@@ -316,16 +316,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "sharp-spearhead",
+                            "qty": 5
                         }
                     ]
                 },
@@ -333,16 +333,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "sharp-spearhead",
+                            "qty": 6
                         }
                     ]
                 }
@@ -393,16 +393,16 @@
                     "description": "Acquire +1 Soul",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 14000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 14000
+                            "item": "sharp-spearhead",
+                            "qty": 2
                         }
                     ]
                 },
@@ -410,16 +410,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 35000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 35000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 }
@@ -496,6 +496,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/bellona.json
+++ b/src/hero/bellona.json
@@ -108,25 +108,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -134,16 +134,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "slime-jelly",
+                            "qty": 5
                         }
                     ]
                 },
@@ -151,16 +151,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "slime-jelly",
+                            "qty": 7
                         }
                     ]
                 },
@@ -168,16 +168,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "dragons-wrath",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "dragons-wrath",
+                            "qty": 2
                         }
                     ]
                 }
@@ -228,25 +228,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -254,16 +254,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "slime-jelly",
+                            "qty": 5
                         }
                     ]
                 },
@@ -271,16 +271,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "slime-jelly",
+                            "qty": 7
                         }
                     ]
                 },
@@ -288,16 +288,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "dragons-wrath",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "dragons-wrath",
+                            "qty": 2
                         }
                     ]
                 }
@@ -338,12 +338,12 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -351,12 +351,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -364,16 +364,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "slime-jelly",
+                            "qty": 5
                         }
                     ]
                 },
@@ -381,16 +381,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "slime-jelly",
+                            "qty": 7
                         }
                     ]
                 },
@@ -398,16 +398,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "dragons-wrath",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "dragons-wrath",
+                            "qty": 2
                         }
                     ]
                 }
@@ -483,6 +483,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/blaze-dingo.json
+++ b/src/hero/blaze-dingo.json
@@ -100,25 +100,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -126,33 +126,33 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "archers-vision",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "archers-vision",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "archers-vision",
+                            "qty": 3
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mercenarys-medicine",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "mercenarys-medicine",
+                            "qty": 2
                         }
                     ]
                 }
@@ -210,25 +210,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -236,33 +236,33 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "archers-vision",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "archers-vision",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "archers-vision",
+                            "qty": 3
                         }
                     ]
                 },
@@ -270,16 +270,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mercenarys-medicine",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "mercenarys-medicine",
+                            "qty": 2
                         }
                     ]
                 }
@@ -320,12 +320,12 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -333,12 +333,12 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -346,33 +346,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "archers-vision",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% healing",
                     "resources": [
-                        {
-                            "item": "archers-vision",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "archers-vision",
+                            "qty": 3
                         }
                     ]
                 },
@@ -380,16 +380,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "mercenarys-medicine",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "mercenarys-medicine",
+                            "qty": 2
                         }
                     ]
                 }
@@ -466,6 +466,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/blood-blade-karin.json
+++ b/src/hero/blood-blade-karin.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -214,42 +214,42 @@
                     "description": "+5% stat increase",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% stat increase",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% stat increase",
                     "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 17000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
@@ -257,16 +257,16 @@
                     "description": "+10% stat increase",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -274,16 +274,16 @@
                     "description": "+15% stat increase",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -324,12 +324,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -337,12 +337,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -350,16 +350,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
@@ -367,16 +367,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -384,16 +384,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -467,6 +467,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/butcher-corps-inquisitor.json
+++ b/src/hero/butcher-corps-inquisitor.json
@@ -96,12 +96,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -109,12 +109,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -122,33 +122,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "twisted-fang",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% effect chance",
                     "resources": [
-                        {
-                            "item": "twisted-fang",
-                            "qty": 2
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 18000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "twisted-fang",
+                            "qty": 2
                         }
                     ]
                 },
@@ -156,16 +156,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 },
@@ -173,16 +173,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "twisted-fang",
+                            "qty": 6
                         }
                     ]
                 }
@@ -223,16 +223,16 @@
                     "description": "-5% damage received limit",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 14000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 14000
+                            "item": "twisted-fang",
+                            "qty": 2
                         }
                     ]
                 },
@@ -240,16 +240,16 @@
                     "description": "-5% damage received limit",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -257,16 +257,16 @@
                     "description": "-5% damage received limit",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 }
@@ -307,12 +307,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -320,12 +320,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -333,33 +333,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "twisted-fang",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "twisted-fang",
-                            "qty": 2
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 18000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "twisted-fang",
+                            "qty": 2
                         }
                     ]
                 },
@@ -367,16 +367,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 },
@@ -384,16 +384,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "twisted-fang",
+                            "qty": 6
                         }
                     ]
                 }
@@ -467,6 +467,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/captain-rikoris.json
+++ b/src/hero/captain-rikoris.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "mysterious-flash",
+                            "qty": 1
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "mysterious-flash",
+                            "qty": 2
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "mysterious-flash",
+                            "qty": 4
                         }
                     ]
                 },
@@ -181,16 +181,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "mysterious-flash",
+                            "qty": 6
                         }
                     ]
                 }
@@ -233,16 +233,16 @@
                     "description": "Acquire +1 Soul",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 14000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 14000
+                            "item": "mysterious-flash",
+                            "qty": 2
                         }
                     ]
                 },
@@ -250,16 +250,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 35000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 35000
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 }
@@ -302,12 +302,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -315,12 +315,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -328,29 +328,29 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% effect chance",
                     "resources": [
-                        {
-                            "item": "mysterious-flash",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 23000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 },
@@ -358,16 +358,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 28000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 28000
+                            "item": "mysterious-flash",
+                            "qty": 4
                         }
                     ]
                 },
@@ -375,16 +375,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "mysterious-flash",
+                            "qty": 5
                         }
                     ]
                 },
@@ -392,16 +392,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "mysterious-flash",
+                            "qty": 6
                         }
                     ]
                 }
@@ -477,6 +477,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "def",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/carmainerose.json
+++ b/src/hero/carmainerose.json
@@ -100,12 +100,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -113,12 +113,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -126,16 +126,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "leather-sheath",
+                            "qty": 3
                         }
                     ]
                 },
@@ -143,16 +143,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "leather-sheath",
+                            "qty": 4
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "leather-sheath",
+                            "qty": 5
                         }
                     ]
                 }
@@ -210,12 +210,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -223,12 +223,12 @@
                     "description": "+10% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -236,16 +236,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "leather-sheath",
+                            "qty": 3
                         }
                     ]
                 },
@@ -253,16 +253,16 @@
                     "description": "+10% Combat Readiness",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "leather-sheath",
+                            "qty": 4
                         }
                     ]
                 },
@@ -270,16 +270,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "leather-sheath",
+                            "qty": 5
                         }
                     ]
                 }
@@ -324,12 +324,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -337,12 +337,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -350,16 +350,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "leather-sheath",
+                            "qty": 3
                         }
                     ]
                 },
@@ -367,16 +367,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "leather-sheath",
+                            "qty": 4
                         }
                     ]
                 },
@@ -384,16 +384,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "leather-sheath",
+                            "qty": 5
                         }
                     ]
                 }
@@ -470,6 +470,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "def",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/carrot.json
+++ b/src/hero/carrot.json
@@ -112,12 +112,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -125,12 +125,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -138,16 +138,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "archers-vision",
+                            "qty": 1
                         }
                     ]
                 },
@@ -155,16 +155,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "archers-vision",
+                            "qty": 2
                         }
                     ]
                 },
@@ -172,16 +172,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "archers-vision",
+                            "qty": 4
                         }
                     ]
                 },
@@ -189,16 +189,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "archers-vision",
+                            "qty": 6
                         }
                     ]
                 }
@@ -241,16 +241,16 @@
                     "description": "+10% trigger chance",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 14000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 14000
+                            "item": "archers-vision",
+                            "qty": 2
                         }
                     ]
                 },
@@ -258,16 +258,16 @@
                     "description": "+10% trigger chance",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 35000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 35000
+                            "item": "archers-vision",
+                            "qty": 3
                         }
                     ]
                 }
@@ -312,12 +312,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -325,25 +325,25 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% effect chance",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -351,16 +351,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "archers-vision",
+                            "qty": 3
                         }
                     ]
                 },
@@ -368,16 +368,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 28000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 28000
+                            "item": "archers-vision",
+                            "qty": 4
                         }
                     ]
                 },
@@ -385,16 +385,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "archers-vision",
+                            "qty": 5
                         }
                     ]
                 },
@@ -402,16 +402,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "archers-vision",
+                            "qty": 6
                         }
                     ]
                 }
@@ -487,6 +487,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/cartuja.json
+++ b/src/hero/cartuja.json
@@ -92,12 +92,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -105,12 +105,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -118,16 +118,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
                         }
                     ]
                 },
@@ -135,33 +135,33 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "baby-mouse-insignia",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "baby-mouse-insignia",
-                            "qty": 4
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 32000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "baby-mouse-insignia",
+                            "qty": 4
                         }
                     ]
                 },
@@ -169,16 +169,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
                         }
                     ]
                 }
@@ -231,16 +231,16 @@
                     "description": "+1% Combat Readiness",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 9000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 9000
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
                         }
                     ]
                 },
@@ -248,16 +248,16 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 31000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 31000
+                            "item": "baby-mouse-insignia",
+                            "qty": 3
                         }
                     ]
                 },
@@ -265,16 +265,16 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 1
                         }
                     ]
                 }
@@ -315,12 +315,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -328,12 +328,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -341,16 +341,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
                         }
                     ]
                 },
@@ -358,16 +358,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "baby-mouse-insignia",
+                            "qty": 2
                         }
                     ]
                 },
@@ -375,16 +375,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "baby-mouse-insignia",
+                            "qty": 4
                         }
                     ]
                 },
@@ -392,16 +392,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
                         }
                     ]
                 }
@@ -487,6 +487,7 @@
         "east": false,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/cecilia.json
+++ b/src/hero/cecilia.json
@@ -111,12 +111,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -124,12 +124,12 @@
                     "description": "5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -137,16 +137,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "path-power-loop",
+                            "qty": 5
                         }
                     ]
                 },
@@ -154,16 +154,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "path-power-loop",
+                            "qty": 7
                         }
                     ]
                 },
@@ -171,16 +171,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "nightmare-mask",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "nightmare-mask",
+                            "qty": 2
                         }
                     ]
                 }
@@ -232,12 +232,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -245,12 +245,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -258,16 +258,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "path-power-loop",
+                            "qty": 5
                         }
                     ]
                 },
@@ -275,16 +275,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "path-power-loop",
+                            "qty": 7
                         }
                     ]
                 },
@@ -292,16 +292,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "nightmare-mask",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "nightmare-mask",
+                            "qty": 2
                         }
                     ]
                 }
@@ -353,12 +353,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -366,12 +366,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -379,16 +379,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "path-power-loop",
+                            "qty": 5
                         }
                     ]
                 },
@@ -396,16 +396,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "path-power-loop",
+                            "qty": 7
                         }
                     ]
                 },
@@ -413,16 +413,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "nightmare-mask",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "nightmare-mask",
+                            "qty": 2
                         }
                     ]
                 }
@@ -510,6 +510,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "def",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/celeste.json
+++ b/src/hero/celeste.json
@@ -100,12 +100,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -113,12 +113,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -126,16 +126,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "archers-vision",
+                            "qty": 1
                         }
                     ]
                 },
@@ -143,16 +143,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "archers-vision",
+                            "qty": 2
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "archers-vision",
+                            "qty": 4
                         }
                     ]
                 },
@@ -177,16 +177,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "archers-vision",
+                            "qty": 6
                         }
                     ]
                 }
@@ -229,12 +229,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -242,25 +242,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -268,16 +268,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "archers-vision",
+                            "qty": 3
                         }
                     ]
                 },
@@ -285,16 +285,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 28000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 28000
+                            "item": "archers-vision",
+                            "qty": 4
                         }
                     ]
                 },
@@ -302,16 +302,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "archers-vision",
+                            "qty": 5
                         }
                     ]
                 },
@@ -319,16 +319,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "archers-vision",
+                            "qty": 6
                         }
                     ]
                 }
@@ -369,16 +369,16 @@
                     "description": "+2 Soul acquired",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 14000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 14000
+                            "item": "archers-vision",
+                            "qty": 2
                         }
                     ]
                 },
@@ -386,16 +386,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 35000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 35000
+                            "item": "archers-vision",
+                            "qty": 3
                         }
                     ]
                 }
@@ -471,6 +471,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "spd",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/celestial-mercedes.json
+++ b/src/hero/celestial-mercedes.json
@@ -108,42 +108,42 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% effect chance",
                     "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 17000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
@@ -151,16 +151,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -168,16 +168,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -220,12 +220,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -233,46 +233,29 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 17000
-                        }
-                    ]
-                },
-                {
-                    "description": "+10% damage dealt",
-                    "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 3
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
@@ -280,16 +263,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 3
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -340,12 +340,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -353,12 +353,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -366,33 +366,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+15% damage dealt",
                     "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -400,16 +400,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -485,6 +485,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "chc",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/cermia.json
+++ b/src/hero/cermia.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -130,12 +130,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -143,16 +143,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 },
@@ -177,16 +177,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 55000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 55000
+                            "item": "twisted-fang",
+                            "qty": 7
                         }
                     ]
                 },
@@ -194,16 +194,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 110000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 110000
+                            "item": "blazing-soul",
+                            "qty": 3
                         }
                     ]
                 }
@@ -246,16 +246,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 8
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "twisted-fang",
+                            "qty": 8
                         }
                     ]
                 }
@@ -298,38 +298,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
-                        }
-                    ]
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": [
+                        },
                         {
                             "item": "molagora",
                             "qty": 2
-                        },
-                        {
-                            "item": "gold",
-                            "qty": 8000
                         }
                     ]
                 },
@@ -337,33 +324,46 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 8000
                         },
                         {
                             "item": "molagora",
-                            "qty": 3
-                        },
+                            "qty": 2
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "twisted-fang",
-                            "qty": 4
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 40000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 },
@@ -371,16 +371,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 55000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 55000
+                            "item": "twisted-fang",
+                            "qty": 7
                         }
                     ]
                 },
@@ -388,16 +388,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 110000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 110000
+                            "item": "blazing-soul",
+                            "qty": 3
                         }
                     ]
                 }
@@ -471,6 +471,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "chc",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/challenger-dominiel.json
+++ b/src/hero/challenger-dominiel.json
@@ -96,25 +96,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -122,16 +122,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
@@ -139,16 +139,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -156,16 +156,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -205,42 +205,42 @@
                     "description": "+5% additional damage",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% additional damage",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+5% additional damage",
                     "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 17000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
@@ -248,16 +248,16 @@
                     "description": "+5% additional damage",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -265,16 +265,16 @@
                     "description": "+10% additional damage",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -314,12 +314,12 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -327,12 +327,12 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -340,33 +340,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+3% Combat Readiness",
                     "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -374,16 +374,16 @@
                     "description": "+3% Combat Readiness",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -459,6 +459,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "chc",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/chaos-sect-axe.json
+++ b/src/hero/chaos-sect-axe.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,16 +117,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "twisted-fang",
+                            "qty": 2
                         }
                     ]
                 },
@@ -134,16 +134,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -151,16 +151,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 }
@@ -203,12 +203,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -216,16 +216,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "twisted-fang",
+                            "qty": 2
                         }
                     ]
                 },
@@ -233,16 +233,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -250,16 +250,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 }
@@ -300,12 +300,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -313,42 +313,42 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% effect chance",
                     "resources": [
-                        {
-                            "item": "twisted-fang",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 23000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -356,16 +356,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 28000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 28000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 },
@@ -373,16 +373,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 },
@@ -390,16 +390,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "twisted-fang",
+                            "qty": 6
                         }
                     ]
                 }
@@ -475,6 +475,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/charles.json
+++ b/src/hero/charles.json
@@ -108,12 +108,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -121,12 +121,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -134,16 +134,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 },
@@ -151,16 +151,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "ring-of-glory",
+                            "qty": 7
                         }
                     ]
                 },
@@ -168,16 +168,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -220,12 +220,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -233,12 +233,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -246,16 +246,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 },
@@ -263,16 +263,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "ring-of-glory",
+                            "qty": 7
                         }
                     ]
                 },
@@ -280,16 +280,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -330,12 +330,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -343,12 +343,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -356,16 +356,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 },
@@ -373,16 +373,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "ring-of-glory",
+                            "qty": 7
                         }
                     ]
                 },
@@ -390,16 +390,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -476,6 +476,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "chc",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/charlotte.json
+++ b/src/hero/charlotte.json
@@ -100,25 +100,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -126,16 +126,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 },
@@ -143,16 +143,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "twisted-fang",
+                            "qty": 7
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -214,12 +214,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -227,12 +227,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -240,16 +240,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 },
@@ -257,16 +257,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "twisted-fang",
+                            "qty": 7
                         }
                     ]
                 },
@@ -274,16 +274,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -326,12 +326,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -339,12 +339,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -352,16 +352,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 },
@@ -369,16 +369,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "twisted-fang",
+                            "qty": 7
                         }
                     ]
                 },
@@ -386,16 +386,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -469,6 +469,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/chloe.json
+++ b/src/hero/chloe.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,29 +117,29 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "archers-vision",
-                            "qty": 5
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 33000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "archers-vision",
+                            "qty": 5
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "archers-vision",
+                            "qty": 7
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mercenarys-medicine",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "mercenarys-medicine",
+                            "qty": 2
                         }
                     ]
                 }
@@ -214,12 +214,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -227,29 +227,29 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "archers-vision",
-                            "qty": 5
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 33000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "archers-vision",
+                            "qty": 5
                         }
                     ]
                 },
@@ -257,16 +257,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "archers-vision",
+                            "qty": 7
                         }
                     ]
                 },
@@ -274,16 +274,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mercenarys-medicine",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "mercenarys-medicine",
+                            "qty": 2
                         }
                     ]
                 }
@@ -326,12 +326,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -339,12 +339,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -352,16 +352,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "archers-vision",
+                            "qty": 5
                         }
                     ]
                 },
@@ -369,16 +369,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "archers-vision",
+                            "qty": 7
                         }
                     ]
                 },
@@ -386,16 +386,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "mercenarys-medicine",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "mercenarys-medicine",
+                            "qty": 2
                         }
                     ]
                 }
@@ -471,6 +471,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/church-of-ilryos-axe.json
+++ b/src/hero/church-of-ilryos-axe.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,16 +117,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "twisted-fang",
+                            "qty": 2
                         }
                     ]
                 },
@@ -134,16 +134,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -151,16 +151,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 }
@@ -203,12 +203,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -216,16 +216,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "twisted-fang",
+                            "qty": 2
                         }
                     ]
                 },
@@ -233,16 +233,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -250,16 +250,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 }
@@ -300,12 +300,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -313,42 +313,42 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% effect chance",
                     "resources": [
-                        {
-                            "item": "twisted-fang",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 23000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -356,16 +356,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 28000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 28000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 },
@@ -373,16 +373,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 },
@@ -390,16 +390,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "twisted-fang",
+                            "qty": 6
                         }
                     ]
                 }
@@ -475,6 +475,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/cidd.json
+++ b/src/hero/cidd.json
@@ -100,25 +100,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -126,33 +126,33 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "path-power-loop",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "path-power-loop",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "path-power-loop",
+                            "qty": 3
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "nightmare-mask",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "nightmare-mask",
+                            "qty": 2
                         }
                     ]
                 }
@@ -221,25 +221,25 @@
                     "description": "+5% damage dealt by Relentless Strike",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt by Relentless Strike",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -247,16 +247,16 @@
                     "description": "+5% damage dealt by Relentless Strike",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "path-power-loop",
+                            "qty": 1
                         }
                     ]
                 },
@@ -264,16 +264,16 @@
                     "description": "+10% damage dealt by Relentless Strike",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "path-power-loop",
+                            "qty": 3
                         }
                     ]
                 },
@@ -281,16 +281,16 @@
                     "description": "+15% damage dealt by Relentless Strike",
                     "resources": [
                         {
-                            "item": "nightmare-mask",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "nightmare-mask",
+                            "qty": 2
                         }
                     ]
                 }
@@ -332,12 +332,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -345,12 +345,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -358,33 +358,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "path-power-loop",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "path-power-loop",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "path-power-loop",
+                            "qty": 3
                         }
                     ]
                 },
@@ -392,16 +392,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "nightmare-mask",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "nightmare-mask",
+                            "qty": 2
                         }
                     ]
                 }
@@ -485,6 +485,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "spd",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/clarissa.json
+++ b/src/hero/clarissa.json
@@ -108,12 +108,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -121,12 +121,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -134,16 +134,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "twisted-fang",
+                            "qty": 1
                         }
                     ]
                 },
@@ -151,16 +151,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -168,16 +168,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -220,25 +220,25 @@
                     "description": "+5% damage dealt by additional skill",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt by additional skill",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -246,33 +246,33 @@
                     "description": "+5% damage dealt by additional skill",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "twisted-fang",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt by additional skill",
                     "resources": [
-                        {
-                            "item": "twisted-fang",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -280,16 +280,16 @@
                     "description": "+10% damage dealt by additional skill",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -330,12 +330,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -343,12 +343,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -356,33 +356,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "twisted-fang",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "twisted-fang",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -390,16 +390,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -475,6 +475,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/coli.json
+++ b/src/hero/coli.json
@@ -108,12 +108,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -121,46 +121,29 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 17000
-                        }
-                    ]
-                },
-                {
-                    "description": "+10% damage dealt",
-                    "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 3
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
@@ -168,16 +151,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 3
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -228,25 +228,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -254,16 +254,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
@@ -271,16 +271,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -288,16 +288,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -351,12 +351,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -364,12 +364,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -377,16 +377,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
@@ -394,16 +394,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -411,16 +411,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -508,6 +508,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/commander-lorina.json
+++ b/src/hero/commander-lorina.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt ",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+5% damage dealt ",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 }
@@ -214,12 +214,12 @@
                     "description": "+0.5% Attack",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -227,12 +227,12 @@
                     "description": "+0.5% Attack",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -240,16 +240,16 @@
                     "description": "+1% Attack",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -257,16 +257,16 @@
                     "description": "+1% Attack",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 },
@@ -274,16 +274,16 @@
                     "description": "+1% Attack",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 }
@@ -324,12 +324,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -337,12 +337,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -350,16 +350,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -367,16 +367,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 },
@@ -384,16 +384,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 }
@@ -467,6 +467,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/corvus.json
+++ b/src/hero/corvus.json
@@ -92,12 +92,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -105,12 +105,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -118,16 +118,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
                         }
                     ]
                 },
@@ -135,33 +135,33 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "baby-mouse-insignia",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "baby-mouse-insignia",
-                            "qty": 4
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 32000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "baby-mouse-insignia",
+                            "qty": 4
                         }
                     ]
                 },
@@ -169,16 +169,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
                         }
                     ]
                 }
@@ -229,12 +229,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -242,12 +242,12 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -255,12 +255,12 @@
                     "description": "+3% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -268,16 +268,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
                         }
                     ]
                 },
@@ -285,16 +285,16 @@
                     "description": "+5% Combat Readiness",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "baby-mouse-insignia",
+                            "qty": 2
                         }
                     ]
                 },
@@ -302,16 +302,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "baby-mouse-insignia",
+                            "qty": 5
                         }
                     ]
                 },
@@ -319,16 +319,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
                         }
                     ]
                 }
@@ -381,16 +381,16 @@
                     "description": "+2 Soul acquired",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "baby-mouse-insignia",
+                            "qty": 3
                         }
                     ]
                 },
@@ -398,16 +398,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 1
                         }
                     ]
                 }
@@ -485,6 +485,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "def",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/crescent-moon-rin.json
+++ b/src/hero/crescent-moon-rin.json
@@ -96,42 +96,42 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "shiny-enchantment",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 17000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "shiny-enchantment",
+                            "qty": 1
                         }
                     ]
                 },
@@ -139,16 +139,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "shiny-enchantment",
+                            "qty": 3
                         }
                     ]
                 },
@@ -156,16 +156,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "horn-of-desire",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "horn-of-desire",
+                            "qty": 2
                         }
                     ]
                 }
@@ -215,42 +215,42 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "shiny-enchantment",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 17000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "shiny-enchantment",
+                            "qty": 1
                         }
                     ]
                 },
@@ -258,16 +258,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "shiny-enchantment",
+                            "qty": 3
                         }
                     ]
                 },
@@ -275,16 +275,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "horn-of-desire",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "horn-of-desire",
+                            "qty": 2
                         }
                     ]
                 }
@@ -325,12 +325,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -338,12 +338,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -351,33 +351,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "shiny-enchantment",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "shiny-enchantment",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "shiny-enchantment",
+                            "qty": 3
                         }
                     ]
                 },
@@ -385,16 +385,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "horn-of-desire",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "horn-of-desire",
+                            "qty": 2
                         }
                     ]
                 }
@@ -470,6 +470,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/crimson-armin.json
+++ b/src/hero/crimson-armin.json
@@ -96,12 +96,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -109,12 +109,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -122,16 +122,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "mysterious-flash",
+                            "qty": 1
                         }
                     ]
                 },
@@ -139,16 +139,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "mysterious-flash",
+                            "qty": 2
                         }
                     ]
                 },
@@ -156,16 +156,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "mysterious-flash",
+                            "qty": 4
                         }
                     ]
                 },
@@ -173,16 +173,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "reingar-student-id",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "reingar-student-id",
+                            "qty": 2
                         }
                     ]
                 }
@@ -235,12 +235,12 @@
                     "description": "+1% additional damage reduction",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -248,25 +248,25 @@
                     "description": "+1% additional damage reduction",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+1% additional damage reduction",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -274,16 +274,16 @@
                     "description": "+1% additional damage reduction",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "mysterious-flash",
+                            "qty": 1
                         }
                     ]
                 },
@@ -291,33 +291,33 @@
                     "description": "+2% additional damage reduction",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "mysterious-flash",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+2% additional damage reduction",
                     "resources": [
-                        {
-                            "item": "mysterious-flash",
-                            "qty": 5
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 45000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "mysterious-flash",
+                            "qty": 5
                         }
                     ]
                 },
@@ -325,16 +325,16 @@
                     "description": "+2% additional damage reduction",
                     "resources": [
                         {
-                            "item": "reingar-student-id",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "reingar-student-id",
+                            "qty": 2
                         }
                     ]
                 }
@@ -375,16 +375,16 @@
                     "description": "+2 Soul acquired",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 },
@@ -392,16 +392,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "reingar-student-id",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "reingar-student-id",
+                            "qty": 1
                         }
                     ]
                 }
@@ -478,6 +478,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "efr",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/crozet.json
+++ b/src/hero/crozet.json
@@ -116,12 +116,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -129,16 +129,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
                         }
                     ]
                 },
@@ -146,16 +146,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 21000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 21000
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
                         }
                     ]
                 },
@@ -163,16 +163,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
                         }
                     ]
                 }
@@ -225,12 +225,12 @@
                     "description": "+5% barrier strength",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -238,16 +238,16 @@
                     "description": "+5% barrier strength",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
                         }
                     ]
                 },
@@ -255,16 +255,16 @@
                     "description": "+10% barrier strength",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 21000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 21000
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
                         }
                     ]
                 },
@@ -272,16 +272,16 @@
                     "description": "+10% barrier strength",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
                         }
                     ]
                 }
@@ -325,12 +325,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -338,25 +338,25 @@
                     "description": "+5% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% Combat Readiness",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -364,16 +364,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
                         }
                     ]
                 },
@@ -381,16 +381,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "baby-mouse-insignia",
+                            "qty": 2
                         }
                     ]
                 },
@@ -398,16 +398,16 @@
                     "description": "+5% Combat Readiness",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "baby-mouse-insignia",
+                            "qty": 5
                         }
                     ]
                 },
@@ -415,16 +415,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
                         }
                     ]
                 }
@@ -508,6 +508,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "efr",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/dark-corvus.json
+++ b/src/hero/dark-corvus.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "slime-jelly",
+                            "qty": 2
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 36000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 36000
+                            "item": "slime-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "slime-jelly",
+                            "qty": 5
                         }
                     ]
                 },
@@ -181,16 +181,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "dragons-wrath",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "dragons-wrath",
+                            "qty": 2
                         }
                     ]
                 }
@@ -243,16 +243,16 @@
                     "description": "+10% activation chance",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 19000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 19000
+                            "item": "slime-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -260,16 +260,16 @@
                     "description": "+10% activation chance",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "slime-jelly",
+                            "qty": 5
                         }
                     ]
                 },
@@ -277,16 +277,16 @@
                     "description": "+10% activation chance",
                     "resources": [
                         {
-                            "item": "dragons-wrath",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 130000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 130000
+                            "item": "dragons-wrath",
+                            "qty": 3
                         }
                     ]
                 }
@@ -327,12 +327,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -340,12 +340,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -353,16 +353,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "slime-jelly",
+                            "qty": 2
                         }
                     ]
                 },
@@ -370,33 +370,33 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 36000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 36000
+                            "item": "slime-jelly",
+                            "qty": 4
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "slime-jelly",
-                            "qty": 5
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 45000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "slime-jelly",
+                            "qty": 5
                         }
                     ]
                 },
@@ -404,16 +404,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "dragons-wrath",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "dragons-wrath",
+                            "qty": 2
                         }
                     ]
                 }
@@ -497,6 +497,7 @@
         "east": false,
         "west": false
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/destina.json
+++ b/src/hero/destina.json
@@ -108,12 +108,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -121,12 +121,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -134,16 +134,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "baby-mouse-insignia",
+                            "qty": 2
                         }
                     ]
                 },
@@ -151,16 +151,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 36000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 36000
+                            "item": "baby-mouse-insignia",
+                            "qty": 4
                         }
                     ]
                 },
@@ -168,16 +168,16 @@
                     "description": "+20% healing",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "baby-mouse-insignia",
+                            "qty": 5
                         }
                     ]
                 },
@@ -185,16 +185,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
                         }
                     ]
                 }
@@ -235,16 +235,16 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 19000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 19000
+                            "item": "baby-mouse-insignia",
+                            "qty": 3
                         }
                     ]
                 },
@@ -252,16 +252,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "baby-mouse-insignia",
+                            "qty": 5
                         }
                     ]
                 },
@@ -269,16 +269,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 130000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 130000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 3
                         }
                     ]
                 }
@@ -319,12 +319,12 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -332,12 +332,12 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -345,16 +345,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "baby-mouse-insignia",
+                            "qty": 2
                         }
                     ]
                 },
@@ -362,33 +362,33 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 36000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 36000
+                            "item": "baby-mouse-insignia",
+                            "qty": 4
                         }
                     ]
                 },
                 {
                     "description": "+10% healing",
                     "resources": [
-                        {
-                            "item": "baby-mouse-insignia",
-                            "qty": 5
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 45000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "baby-mouse-insignia",
+                            "qty": 5
                         }
                     ]
                 },
@@ -396,16 +396,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
                         }
                     ]
                 }
@@ -479,6 +479,7 @@
         "east": true,
         "west": false
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/diene.json
+++ b/src/hero/diene.json
@@ -116,12 +116,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -129,12 +129,12 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -142,29 +142,29 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "ring-of-glory",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -172,33 +172,33 @@
                     "description": "+3% Combat Readiness",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "ring-of-glory",
+                            "qty": 4
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "ring-of-glory",
-                            "qty": 7
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 55000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 7
                         }
                     ]
                 },
@@ -206,16 +206,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 110000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 110000
+                            "item": "fused-nerve",
+                            "qty": 3
                         }
                     ]
                 }
@@ -256,12 +256,12 @@
                     "description": "+5% barrier strength",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -269,12 +269,12 @@
                     "description": "+5% barrier strength",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -282,16 +282,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "ring-of-glory",
+                            "qty": 2
                         }
                     ]
                 },
@@ -299,33 +299,33 @@
                     "description": "+10% barrier strength",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 36000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 36000
+                            "item": "ring-of-glory",
+                            "qty": 4
                         }
                     ]
                 },
                 {
                     "description": "+15% barrier strength",
                     "resources": [
-                        {
-                            "item": "ring-of-glory",
-                            "qty": 5
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 45000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 },
@@ -333,16 +333,16 @@
                     "description": "+15% barrier strength",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -385,16 +385,16 @@
                     "description": "Acquire +1 soul",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 },
@@ -402,16 +402,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -488,6 +488,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/dingo.json
+++ b/src/hero/dingo.json
@@ -96,12 +96,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -109,29 +109,29 @@
                     "description": "+5 damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+5% chance of inflicting bleeding",
                     "resources": [
-                        {
-                            "item": "flame-of-soul",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 13000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "flame-of-soul",
+                            "qty": 1
                         }
                     ]
                 },
@@ -139,33 +139,33 @@
                     "description": "+5% chance of inflicting bleeding",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "flame-of-soul",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "flame-of-soul",
-                            "qty": 4
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 32000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "flame-of-soul",
+                            "qty": 4
                         }
                     ]
                 },
@@ -173,16 +173,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "demon-blood-gem",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "demon-blood-gem",
+                            "qty": 2
                         }
                     ]
                 }
@@ -225,12 +225,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -238,12 +238,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -251,12 +251,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -264,16 +264,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "flame-of-soul",
+                            "qty": 1
                         }
                     ]
                 },
@@ -281,33 +281,33 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "flame-of-soul",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "flame-of-soul",
-                            "qty": 5
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 45000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "flame-of-soul",
+                            "qty": 5
                         }
                     ]
                 },
@@ -315,16 +315,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "demon-blood-gem",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "demon-blood-gem",
+                            "qty": 2
                         }
                     ]
                 }
@@ -367,16 +367,16 @@
                     "description": "Acquire +1 Soul",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "flame-of-soul",
+                            "qty": 3
                         }
                     ]
                 },
@@ -384,16 +384,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "demon-blood-gem",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "demon-blood-gem",
+                            "qty": 1
                         }
                     ]
                 }
@@ -467,6 +467,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "dac",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/dizzy.json
+++ b/src/hero/dizzy.json
@@ -104,25 +104,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "shiny-enchantment",
+                            "qty": 5
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "shiny-enchantment",
+                            "qty": 7
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "horn-of-desire",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "horn-of-desire",
+                            "qty": 2
                         }
                     ]
                 }
@@ -216,12 +216,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -229,12 +229,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -242,16 +242,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "shiny-enchantment",
+                            "qty": 5
                         }
                     ]
                 },
@@ -259,16 +259,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "shiny-enchantment",
+                            "qty": 7
                         }
                     ]
                 },
@@ -276,16 +276,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "horn-of-desire",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "horn-of-desire",
+                            "qty": 2
                         }
                     ]
                 }
@@ -326,12 +326,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -339,12 +339,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -352,16 +352,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "shiny-enchantment",
+                            "qty": 5
                         }
                     ]
                 },
@@ -369,16 +369,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "shiny-enchantment",
+                            "qty": 7
                         }
                     ]
                 },
@@ -386,16 +386,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "horn-of-desire",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "horn-of-desire",
+                            "qty": 2
                         }
                     ]
                 }
@@ -473,6 +473,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/dominiel.json
+++ b/src/hero/dominiel.json
@@ -100,12 +100,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -113,12 +113,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -126,16 +126,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "shiny-enchantment",
+                            "qty": 1
                         }
                     ]
                 },
@@ -143,33 +143,33 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "shiny-enchantment",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "shiny-enchantment",
-                            "qty": 4
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 32000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "shiny-enchantment",
+                            "qty": 4
                         }
                     ]
                 },
@@ -177,16 +177,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "horn-of-desire",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "horn-of-desire",
+                            "qty": 2
                         }
                     ]
                 }
@@ -229,16 +229,16 @@
                     "description": "Acquire +1 Soul",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "shiny-enchantment",
+                            "qty": 3
                         }
                     ]
                 },
@@ -246,16 +246,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "horn-of-desire",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "horn-of-desire",
+                            "qty": 1
                         }
                     ]
                 }
@@ -299,12 +299,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -312,12 +312,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -325,12 +325,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -338,16 +338,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "shiny-enchantment",
+                            "qty": 1
                         }
                     ]
                 },
@@ -355,16 +355,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "shiny-enchantment",
+                            "qty": 2
                         }
                     ]
                 },
@@ -372,16 +372,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "shiny-enchantment",
+                            "qty": 5
                         }
                     ]
                 },
@@ -389,16 +389,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "horn-of-desire",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "horn-of-desire",
+                            "qty": 2
                         }
                     ]
                 }
@@ -474,6 +474,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "def",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/doris.json
+++ b/src/hero/doris.json
@@ -100,12 +100,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -113,12 +113,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -126,16 +126,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "baby-mouse-insignia",
+                            "qty": 3
                         }
                     ]
                 },
@@ -143,16 +143,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "baby-mouse-insignia",
+                            "qty": 4
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "baby-mouse-insignia",
+                            "qty": 5
                         }
                     ]
                 }
@@ -212,12 +212,12 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -225,12 +225,12 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -238,16 +238,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "baby-mouse-insignia",
+                            "qty": 3
                         }
                     ]
                 },
@@ -255,16 +255,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "baby-mouse-insignia",
+                            "qty": 4
                         }
                     ]
                 },
@@ -272,16 +272,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "baby-mouse-insignia",
+                            "qty": 5
                         }
                     ]
                 }
@@ -325,12 +325,12 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -338,12 +338,12 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -351,16 +351,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "baby-mouse-insignia",
+                            "qty": 3
                         }
                     ]
                 },
@@ -368,16 +368,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "baby-mouse-insignia",
+                            "qty": 4
                         }
                     ]
                 },
@@ -385,16 +385,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "baby-mouse-insignia",
+                            "qty": 5
                         }
                     ]
                 }
@@ -468,6 +468,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/elson.json
+++ b/src/hero/elson.json
@@ -100,12 +100,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -113,12 +113,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -126,16 +126,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "strange-jelly",
+                            "qty": 1
                         }
                     ]
                 },
@@ -143,16 +143,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "strange-jelly",
+                            "qty": 2
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "strange-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -177,16 +177,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "strange-jelly",
+                            "qty": 6
                         }
                     ]
                 }
@@ -229,12 +229,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -242,42 +242,42 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+15% healing",
                     "resources": [
-                        {
-                            "item": "strange-jelly",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 23000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "strange-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -285,16 +285,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 28000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 28000
+                            "item": "strange-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -302,16 +302,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "strange-jelly",
+                            "qty": 5
                         }
                     ]
                 },
@@ -319,16 +319,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "strange-jelly",
+                            "qty": 6
                         }
                     ]
                 }
@@ -369,16 +369,16 @@
                     "description": "+2 Soul acquired",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 14000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 14000
+                            "item": "strange-jelly",
+                            "qty": 2
                         }
                     ]
                 },
@@ -386,16 +386,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 35000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 35000
+                            "item": "strange-jelly",
+                            "qty": 3
                         }
                     ]
                 }
@@ -472,6 +472,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "def",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/enott.json
+++ b/src/hero/enott.json
@@ -100,12 +100,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -113,12 +113,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -126,16 +126,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -143,16 +143,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "sharp-spearhead",
+                            "qty": 4
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "sharp-spearhead",
+                            "qty": 5
                         }
                     ]
                 }
@@ -212,12 +212,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -225,12 +225,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -238,16 +238,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -255,16 +255,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "sharp-spearhead",
+                            "qty": 4
                         }
                     ]
                 },
@@ -272,16 +272,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "sharp-spearhead",
+                            "qty": 5
                         }
                     ]
                 }
@@ -325,12 +325,12 @@
                     "description": "Acquire +1 Soul",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -338,12 +338,12 @@
                     "description": "+5% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -351,16 +351,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -368,16 +368,16 @@
                     "description": "+5% Combat Readiness",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "sharp-spearhead",
+                            "qty": 4
                         }
                     ]
                 },
@@ -385,16 +385,16 @@
                     "description": "+10% Combat Readiness",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "sharp-spearhead",
+                            "qty": 5
                         }
                     ]
                 }
@@ -471,6 +471,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/falconer-kluri.json
+++ b/src/hero/falconer-kluri.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+5% Combat Readiness",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "path-power-loop",
+                            "qty": 1
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "path-power-loop",
+                            "qty": 2
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "path-power-loop",
+                            "qty": 4
                         }
                     ]
                 },
@@ -181,16 +181,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "path-power-loop",
+                            "qty": 6
                         }
                     ]
                 }
@@ -241,12 +241,12 @@
                     "description": "+0.5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -254,46 +254,29 @@
                     "description": "+0.5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+1% healing",
                     "resources": [
-                        {
-                            "item": "path-power-loop",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 13000
-                        }
-                    ]
-                },
-                {
-                    "description": "+1% healing",
-                    "resources": [
-                        {
-                            "item": "path-power-loop",
-                            "qty": 2
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "path-power-loop",
+                            "qty": 1
                         }
                     ]
                 },
@@ -301,16 +284,33 @@
                     "description": "+1% healing",
                     "resources": [
                         {
+                            "item": "gold",
+                            "qty": 18000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
                             "item": "path-power-loop",
-                            "qty": 4
+                            "qty": 2
+                        }
+                    ]
+                },
+                {
+                    "description": "+1% healing",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "path-power-loop",
+                            "qty": 4
                         }
                     ]
                 },
@@ -318,16 +318,16 @@
                     "description": "+1% healing",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "path-power-loop",
+                            "qty": 6
                         }
                     ]
                 }
@@ -368,16 +368,16 @@
                     "description": "+10% Defense decrease, provoke chance",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 14000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 14000
+                            "item": "path-power-loop",
+                            "qty": 2
                         }
                     ]
                 },
@@ -385,16 +385,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "path-power-loop",
+                            "qty": 3
                         }
                     ]
                 },
@@ -402,16 +402,16 @@
                     "description": "+15% Defense decrease, provoke chance",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "path-power-loop",
+                            "qty": 5
                         }
                     ]
                 }
@@ -488,6 +488,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "def",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/fallen-cecilia.json
+++ b/src/hero/fallen-cecilia.json
@@ -96,12 +96,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -109,12 +109,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -122,16 +122,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "archers-vision",
+                            "qty": 5
                         }
                     ]
                 },
@@ -139,16 +139,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "archers-vision",
+                            "qty": 7
                         }
                     ]
                 },
@@ -156,16 +156,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "mercenarys-medicine",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "mercenarys-medicine",
+                            "qty": 2
                         }
                     ]
                 }
@@ -208,25 +208,25 @@
                     "description": "+5% barrier strength",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% barrier strength",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -234,16 +234,16 @@
                     "description": "+10% barrier strength",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "archers-vision",
+                            "qty": 5
                         }
                     ]
                 },
@@ -251,16 +251,16 @@
                     "description": "+10% barrier strength",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "archers-vision",
+                            "qty": 7
                         }
                     ]
                 },
@@ -268,16 +268,16 @@
                     "description": "+15% barrier strength",
                     "resources": [
                         {
-                            "item": "mercenarys-medicine",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "mercenarys-medicine",
+                            "qty": 2
                         }
                     ]
                 }
@@ -320,12 +320,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -333,12 +333,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -346,16 +346,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "archers-vision",
+                            "qty": 5
                         }
                     ]
                 },
@@ -363,16 +363,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "archers-vision",
+                            "qty": 7
                         }
                     ]
                 },
@@ -380,16 +380,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "mercenarys-medicine",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "mercenarys-medicine",
+                            "qty": 2
                         }
                     ]
                 }
@@ -465,6 +465,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "efr",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/fighter-maya.json
+++ b/src/hero/fighter-maya.json
@@ -96,25 +96,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -122,16 +122,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "mysterious-flash",
+                            "qty": 1
                         }
                     ]
                 },
@@ -139,16 +139,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 },
@@ -156,16 +156,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "reingar-student-id",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "reingar-student-id",
+                            "qty": 2
                         }
                     ]
                 }
@@ -218,12 +218,12 @@
                     "description": "+3% trigger chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -231,12 +231,12 @@
                     "description": "+3% trigger chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -244,33 +244,33 @@
                     "description": "+4% trigger chance",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "mysterious-flash",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% trigger chance",
                     "resources": [
-                        {
-                            "item": "mysterious-flash",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 },
@@ -278,16 +278,16 @@
                     "description": "+5% trigger chance",
                     "resources": [
                         {
-                            "item": "reingar-student-id",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "reingar-student-id",
+                            "qty": 2
                         }
                     ]
                 }
@@ -330,12 +330,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -343,12 +343,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -356,33 +356,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "mysterious-flash",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "mysterious-flash",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 },
@@ -390,16 +390,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "reingar-student-id",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "reingar-student-id",
+                            "qty": 2
                         }
                     ]
                 }
@@ -483,6 +483,7 @@
         "east": false,
         "west": true
     },
+    "memoryImprintAttribute": "efr",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/general-purrgis.json
+++ b/src/hero/general-purrgis.json
@@ -104,25 +104,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% effect chance",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "baby-mouse-insignia",
+                            "qty": 2
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "baby-mouse-insignia",
+                            "qty": 4
                         }
                     ]
                 },
@@ -181,16 +181,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
                         }
                     ]
                 }
@@ -233,16 +233,16 @@
                     "description": "+1% Combat Readiness",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 9000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 9000
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
                         }
                     ]
                 },
@@ -250,16 +250,16 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 31000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 31000
+                            "item": "baby-mouse-insignia",
+                            "qty": 3
                         }
                     ]
                 },
@@ -267,16 +267,16 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 1
                         }
                     ]
                 }
@@ -317,12 +317,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -330,12 +330,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -343,16 +343,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
                         }
                     ]
                 },
@@ -360,16 +360,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "baby-mouse-insignia",
+                            "qty": 2
                         }
                     ]
                 },
@@ -377,16 +377,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "baby-mouse-insignia",
+                            "qty": 4
                         }
                     ]
                 },
@@ -394,16 +394,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
                         }
                     ]
                 }
@@ -481,6 +481,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/giga-phantasma.json
+++ b/src/hero/giga-phantasma.json
@@ -112,6 +112,7 @@
         "east": false,
         "west": false
     },
+    "memoryImprintAttribute": "",
     "memoryImprint": [],
     "awakening": []
 }

--- a/src/hero/gloomyrain.json
+++ b/src/hero/gloomyrain.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+2% effect chance",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "baby-mouse-insignia",
+                            "qty": 2
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+3% effect chance",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "baby-mouse-insignia",
+                            "qty": 4
                         }
                     ]
                 },
@@ -181,16 +181,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "baby-mouse-insignia",
+                            "qty": 6
                         }
                     ]
                 }
@@ -231,16 +231,16 @@
                     "description": "+5% Speed and damage dealt",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 14000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 14000
+                            "item": "baby-mouse-insignia",
+                            "qty": 2
                         }
                     ]
                 },
@@ -248,16 +248,16 @@
                     "description": "+5% Speed and damage dealt",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "baby-mouse-insignia",
+                            "qty": 3
                         }
                     ]
                 },
@@ -265,16 +265,16 @@
                     "description": "+5% Speed and damage dealt",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "baby-mouse-insignia",
+                            "qty": 5
                         }
                     ]
                 }
@@ -315,12 +315,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -328,12 +328,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -341,16 +341,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
                         }
                     ]
                 },
@@ -358,16 +358,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "baby-mouse-insignia",
+                            "qty": 2
                         }
                     ]
                 },
@@ -375,16 +375,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "baby-mouse-insignia",
+                            "qty": 4
                         }
                     ]
                 },
@@ -392,16 +392,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "baby-mouse-insignia",
+                            "qty": 6
                         }
                     ]
                 }
@@ -475,6 +475,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "spd",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/guider-aither.json
+++ b/src/hero/guider-aither.json
@@ -112,12 +112,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -125,12 +125,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -138,16 +138,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
                         }
                     ]
                 },
@@ -155,16 +155,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "baby-mouse-insignia",
+                            "qty": 3
                         }
                     ]
                 },
@@ -172,16 +172,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
                         }
                     ]
                 }
@@ -224,12 +224,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -237,46 +237,29 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "baby-mouse-insignia",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 17000
-                        }
-                    ]
-                },
-                {
-                    "description": "+10% damage dealt",
-                    "resources": [
-                        {
-                            "item": "baby-mouse-insignia",
-                            "qty": 3
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
                         }
                     ]
                 },
@@ -284,16 +267,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "baby-mouse-insignia",
+                            "qty": 3
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
                         }
                     ]
                 }
@@ -336,12 +336,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -349,12 +349,12 @@
                     "description": "+20% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -362,16 +362,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
                         }
                     ]
                 },
@@ -379,16 +379,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "baby-mouse-insignia",
+                            "qty": 3
                         }
                     ]
                 },
@@ -396,16 +396,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
                         }
                     ]
                 }
@@ -481,6 +481,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/gunther.json
+++ b/src/hero/gunther.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "mysterious-flash",
+                            "qty": 4
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "mysterious-flash",
+                            "qty": 5
                         }
                     ]
                 }
@@ -216,12 +216,12 @@
                     "description": "+5% Attack",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -229,12 +229,12 @@
                     "description": "+5% Attack",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -242,16 +242,16 @@
                     "description": "+5% Attack",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 },
@@ -259,16 +259,16 @@
                     "description": "+5% Attack",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "mysterious-flash",
+                            "qty": 4
                         }
                     ]
                 },
@@ -276,16 +276,16 @@
                     "description": "+5% Attack",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "mysterious-flash",
+                            "qty": 5
                         }
                     ]
                 }
@@ -326,12 +326,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -339,12 +339,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -352,16 +352,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 },
@@ -369,16 +369,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "mysterious-flash",
+                            "qty": 4
                         }
                     ]
                 },
@@ -386,16 +386,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "mysterious-flash",
+                            "qty": 5
                         }
                     ]
                 }
@@ -471,6 +471,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/haste.json
+++ b/src/hero/haste.json
@@ -100,12 +100,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -113,12 +113,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -126,16 +126,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 },
@@ -143,16 +143,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "ring-of-glory",
+                            "qty": 7
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -212,12 +212,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -225,12 +225,12 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -238,16 +238,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 },
@@ -255,16 +255,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "ring-of-glory",
+                            "qty": 7
                         }
                     ]
                 },
@@ -272,16 +272,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -325,12 +325,12 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -338,12 +338,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -351,16 +351,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 },
@@ -368,16 +368,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "ring-of-glory",
+                            "qty": 7
                         }
                     ]
                 },
@@ -385,16 +385,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -470,6 +470,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/hazel.json
+++ b/src/hero/hazel.json
@@ -104,12 +104,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,16 +117,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "leather-sheath",
+                            "qty": 2
                         }
                     ]
                 },
@@ -134,16 +134,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "leather-sheath",
+                            "qty": 3
                         }
                     ]
                 },
@@ -151,16 +151,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "leather-sheath",
+                            "qty": 4
                         }
                     ]
                 }
@@ -203,29 +203,29 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% healing",
                     "resources": [
-                        {
-                            "item": "leather-sheath",
-                            "qty": 2
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 18000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "leather-sheath",
+                            "qty": 2
                         }
                     ]
                 },
@@ -233,16 +233,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "leather-sheath",
+                            "qty": 3
                         }
                     ]
                 },
@@ -250,16 +250,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "leather-sheath",
+                            "qty": 4
                         }
                     ]
                 }
@@ -300,12 +300,12 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -313,25 +313,25 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% healing",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -339,33 +339,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "leather-sheath",
+                            "qty": 3
                         }
                     ]
                 },
                 {
                     "description": "+10% healing",
                     "resources": [
-                        {
-                            "item": "leather-sheath",
-                            "qty": 4
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 28000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "leather-sheath",
+                            "qty": 4
                         }
                     ]
                 },
@@ -373,16 +373,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "leather-sheath",
+                            "qty": 5
                         }
                     ]
                 },
@@ -390,16 +390,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "leather-sheath",
+                            "qty": 6
                         }
                     ]
                 }
@@ -475,6 +475,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/helga.json
+++ b/src/hero/helga.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -130,29 +130,29 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+5% effect chance",
                     "resources": [
-                        {
-                            "item": "archers-vision",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 23000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "archers-vision",
+                            "qty": 3
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 28000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 28000
+                            "item": "archers-vision",
+                            "qty": 4
                         }
                     ]
                 },
@@ -177,16 +177,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "archers-vision",
+                            "qty": 5
                         }
                     ]
                 },
@@ -194,16 +194,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "archers-vision",
+                            "qty": 6
                         }
                     ]
                 }
@@ -246,12 +246,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -259,46 +259,29 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "archers-vision",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 13000
-                        }
-                    ]
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": [
-                        {
-                            "item": "archers-vision",
-                            "qty": 2
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "archers-vision",
+                            "qty": 1
                         }
                     ]
                 },
@@ -306,16 +289,33 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
+                            "item": "gold",
+                            "qty": 18000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
                             "item": "archers-vision",
-                            "qty": 4
+                            "qty": 2
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "archers-vision",
+                            "qty": 4
                         }
                     ]
                 },
@@ -323,16 +323,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "archers-vision",
+                            "qty": 6
                         }
                     ]
                 }
@@ -373,16 +373,16 @@
                     "description": "Acquire +1 Soul",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 14000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 14000
+                            "item": "archers-vision",
+                            "qty": 2
                         }
                     ]
                 },
@@ -390,16 +390,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 35000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 35000
+                            "item": "archers-vision",
+                            "qty": 3
                         }
                     ]
                 }
@@ -475,6 +475,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "spd",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/hurado.json
+++ b/src/hero/hurado.json
@@ -100,12 +100,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -113,12 +113,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -126,16 +126,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "strange-jelly",
+                            "qty": 1
                         }
                     ]
                 },
@@ -143,16 +143,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "strange-jelly",
+                            "qty": 2
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "strange-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -177,16 +177,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "strange-jelly",
+                            "qty": 6
                         }
                     ]
                 }
@@ -229,16 +229,16 @@
                     "description": "+5% healing reduction",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 14000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 14000
+                            "item": "strange-jelly",
+                            "qty": 2
                         }
                     ]
                 },
@@ -246,16 +246,16 @@
                     "description": "+5% healing reduction",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "strange-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -263,16 +263,16 @@
                     "description": "+5% healing reduction",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "strange-jelly",
+                            "qty": 5
                         }
                     ]
                 }
@@ -313,12 +313,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -326,12 +326,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -339,16 +339,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "strange-jelly",
+                            "qty": 1
                         }
                     ]
                 },
@@ -356,16 +356,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "strange-jelly",
+                            "qty": 2
                         }
                     ]
                 },
@@ -373,16 +373,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "strange-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -390,16 +390,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "strange-jelly",
+                            "qty": 6
                         }
                     ]
                 }
@@ -473,6 +473,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/iseria.json
+++ b/src/hero/iseria.json
@@ -116,12 +116,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -129,12 +129,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -142,12 +142,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -155,16 +155,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -172,33 +172,33 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "twisted-fang",
-                            "qty": 7
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 55000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "twisted-fang",
+                            "qty": 7
                         }
                     ]
                 },
@@ -206,16 +206,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 110000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 110000
+                            "item": "blazing-soul",
+                            "qty": 3
                         }
                     ]
                 }
@@ -258,16 +258,16 @@
                     "description": "+2 Soul acquired",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 },
@@ -275,16 +275,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -325,12 +325,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -338,12 +338,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -351,16 +351,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "twisted-fang",
+                            "qty": 2
                         }
                     ]
                 },
@@ -368,33 +368,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 36000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 36000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "twisted-fang",
-                            "qty": 5
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 45000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 },
@@ -402,16 +402,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -488,6 +488,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/jecht.json
+++ b/src/hero/jecht.json
@@ -100,12 +100,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -113,16 +113,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "archers-vision",
+                            "qty": 2
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "archers-vision",
+                            "qty": 3
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "archers-vision",
+                            "qty": 4
                         }
                     ]
                 }
@@ -199,46 +199,29 @@
                     "description": "+5% dispel chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% dispel chance",
                     "resources": [
-                        {
-                            "item": "archers-vision",
-                            "qty": 2
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 18000
-                        }
-                    ]
-                },
-                {
-                    "description": "+5% dispel chance",
-                    "resources": [
-                        {
-                            "item": "archers-vision",
-                            "qty": 3
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "archers-vision",
+                            "qty": 2
                         }
                     ]
                 },
@@ -246,16 +229,33 @@
                     "description": "+5% dispel chance",
                     "resources": [
                         {
+                            "item": "gold",
+                            "qty": 23000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
                             "item": "archers-vision",
-                            "qty": 4
+                            "qty": 3
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% dispel chance",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "archers-vision",
+                            "qty": 4
                         }
                     ]
                 }
@@ -296,12 +296,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -309,25 +309,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -335,16 +335,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "archers-vision",
+                            "qty": 3
                         }
                     ]
                 },
@@ -352,16 +352,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 28000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 28000
+                            "item": "archers-vision",
+                            "qty": 4
                         }
                     ]
                 },
@@ -369,16 +369,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "archers-vision",
+                            "qty": 5
                         }
                     ]
                 },
@@ -386,16 +386,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "archers-vision",
+                            "qty": 6
                         }
                     ]
                 }
@@ -472,6 +472,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "spd",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/jena.json
+++ b/src/hero/jena.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,16 +117,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "path-power-loop",
+                            "qty": 2
                         }
                     ]
                 },
@@ -134,16 +134,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "path-power-loop",
+                            "qty": 3
                         }
                     ]
                 },
@@ -151,16 +151,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "path-power-loop",
+                            "qty": 4
                         }
                     ]
                 }
@@ -201,12 +201,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -214,16 +214,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "path-power-loop",
+                            "qty": 2
                         }
                     ]
                 },
@@ -231,16 +231,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "path-power-loop",
+                            "qty": 3
                         }
                     ]
                 },
@@ -248,16 +248,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "path-power-loop",
+                            "qty": 4
                         }
                     ]
                 }
@@ -301,12 +301,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -314,12 +314,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -327,12 +327,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -340,16 +340,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "path-power-loop",
+                            "qty": 3
                         }
                     ]
                 },
@@ -357,16 +357,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 28000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 28000
+                            "item": "path-power-loop",
+                            "qty": 4
                         }
                     ]
                 },
@@ -374,16 +374,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "path-power-loop",
+                            "qty": 5
                         }
                     ]
                 },
@@ -391,16 +391,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "path-power-loop",
+                            "qty": 6
                         }
                     ]
                 }
@@ -476,6 +476,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/judge-kise.json
+++ b/src/hero/judge-kise.json
@@ -112,12 +112,12 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -125,16 +125,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "flame-of-soul",
+                            "qty": 3
                         }
                     ]
                 },
@@ -142,16 +142,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 49000
                         },
                         {
                             "item": "molagora",
                             "qty": 6
                         },
                         {
-                            "item": "gold",
-                            "qty": 49000
+                            "item": "flame-of-soul",
+                            "qty": 5
                         }
                     ]
                 },
@@ -159,16 +159,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "demon-blood-gem",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "demon-blood-gem",
+                            "qty": 2
                         }
                     ]
                 }
@@ -211,12 +211,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -224,16 +224,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "flame-of-soul",
+                            "qty": 3
                         }
                     ]
                 },
@@ -241,16 +241,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 49000
                         },
                         {
                             "item": "molagora",
                             "qty": 6
                         },
                         {
-                            "item": "gold",
-                            "qty": 49000
+                            "item": "flame-of-soul",
+                            "qty": 5
                         }
                     ]
                 },
@@ -258,16 +258,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "demon-blood-gem",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "demon-blood-gem",
+                            "qty": 2
                         }
                     ]
                 }
@@ -308,12 +308,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -321,12 +321,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -334,12 +334,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -347,16 +347,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "flame-of-soul",
+                            "qty": 3
                         }
                     ]
                 },
@@ -364,16 +364,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "flame-of-soul",
+                            "qty": 4
                         }
                     ]
                 },
@@ -381,16 +381,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 55000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 55000
+                            "item": "flame-of-soul",
+                            "qty": 7
                         }
                     ]
                 },
@@ -398,16 +398,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "demon-blood-gem",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 110000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 110000
+                            "item": "demon-blood-gem",
+                            "qty": 3
                         }
                     ]
                 }
@@ -481,6 +481,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "eff",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/judith.json
+++ b/src/hero/judith.json
@@ -100,12 +100,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -113,12 +113,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -126,16 +126,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "strange-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -143,16 +143,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "strange-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "strange-jelly",
+                            "qty": 5
                         }
                     ]
                 }
@@ -212,12 +212,12 @@
                     "description": "+5% trigger chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -225,12 +225,12 @@
                     "description": "+5% trigger chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -238,16 +238,16 @@
                     "description": "+5% trigger chance",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "strange-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -255,16 +255,16 @@
                     "description": "+5% trigger chance",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "strange-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -272,16 +272,16 @@
                     "description": "+10% trigger chance",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "strange-jelly",
+                            "qty": 5
                         }
                     ]
                 }
@@ -324,12 +324,12 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -337,12 +337,12 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -350,16 +350,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "strange-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -367,16 +367,16 @@
                     "description": "+3% Combat Readiness",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "strange-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -384,16 +384,16 @@
                     "description": "+3% Combat Readiness",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "strange-jelly",
+                            "qty": 5
                         }
                     ]
                 }
@@ -469,6 +469,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/karin.json
+++ b/src/hero/karin.json
@@ -116,12 +116,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -129,16 +129,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "twisted-fang",
+                            "qty": 1
                         }
                     ]
                 },
@@ -146,16 +146,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 21000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 21000
+                            "item": "twisted-fang",
+                            "qty": 1
                         }
                     ]
                 },
@@ -163,16 +163,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -213,12 +213,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -226,16 +226,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "twisted-fang",
+                            "qty": 1
                         }
                     ]
                 },
@@ -243,16 +243,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 21000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 21000
+                            "item": "twisted-fang",
+                            "qty": 1
                         }
                     ]
                 },
@@ -260,16 +260,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -312,12 +312,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -325,25 +325,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -351,16 +351,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "twisted-fang",
+                            "qty": 1
                         }
                     ]
                 },
@@ -368,33 +368,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "twisted-fang",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "twisted-fang",
-                            "qty": 5
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 45000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 },
@@ -402,16 +402,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -485,6 +485,7 @@
         "east": false,
         "west": true
     },
+    "memoryImprintAttribute": "chc",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/kayron.json
+++ b/src/hero/kayron.json
@@ -108,12 +108,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -121,12 +121,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -134,16 +134,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "path-power-loop",
+                            "qty": 2
                         }
                     ]
                 },
@@ -151,16 +151,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 36000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 36000
+                            "item": "path-power-loop",
+                            "qty": 4
                         }
                     ]
                 },
@@ -168,16 +168,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "path-power-loop",
+                            "qty": 5
                         }
                     ]
                 },
@@ -185,16 +185,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "nightmare-mask",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "nightmare-mask",
+                            "qty": 2
                         }
                     ]
                 }
@@ -237,16 +237,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 19000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 19000
+                            "item": "path-power-loop",
+                            "qty": 3
                         }
                     ]
                 },
@@ -254,16 +254,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "path-power-loop",
+                            "qty": 5
                         }
                     ]
                 },
@@ -271,16 +271,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "nightmare-mask",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 130000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 130000
+                            "item": "nightmare-mask",
+                            "qty": 3
                         }
                     ]
                 }
@@ -323,12 +323,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -336,12 +336,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -349,16 +349,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "path-power-loop",
+                            "qty": 2
                         }
                     ]
                 },
@@ -366,33 +366,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 36000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 36000
+                            "item": "path-power-loop",
+                            "qty": 4
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "path-power-loop",
-                            "qty": 5
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 45000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "path-power-loop",
+                            "qty": 5
                         }
                     ]
                 },
@@ -400,16 +400,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "nightmare-mask",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "nightmare-mask",
+                            "qty": 2
                         }
                     ]
                 }
@@ -485,6 +485,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/ken.json
+++ b/src/hero/ken.json
@@ -96,12 +96,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -109,12 +109,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -122,16 +122,16 @@
                     "description": "+5 Fighting Spirit acquired",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "slime-jelly",
+                            "qty": 2
                         }
                     ]
                 },
@@ -139,16 +139,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 36000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 36000
+                            "item": "slime-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -156,16 +156,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "slime-jelly",
+                            "qty": 5
                         }
                     ]
                 },
@@ -173,16 +173,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "dragons-wrath",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "dragons-wrath",
+                            "qty": 2
                         }
                     ]
                 }
@@ -236,16 +236,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 19000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 19000
+                            "item": "slime-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -253,16 +253,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "slime-jelly",
+                            "qty": 5
                         }
                     ]
                 },
@@ -270,16 +270,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "dragons-wrath",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 130000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 130000
+                            "item": "dragons-wrath",
+                            "qty": 3
                         }
                     ]
                 }
@@ -335,12 +335,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -348,12 +348,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -361,16 +361,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "slime-jelly",
+                            "qty": 2
                         }
                     ]
                 },
@@ -378,16 +378,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 36000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 36000
+                            "item": "slime-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -395,16 +395,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "slime-jelly",
+                            "qty": 5
                         }
                     ]
                 },
@@ -412,16 +412,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "dragons-wrath",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "dragons-wrath",
+                            "qty": 2
                         }
                     ]
                 }
@@ -508,6 +508,7 @@
         "east": false,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/khawazu.json
+++ b/src/hero/khawazu.json
@@ -103,12 +103,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -116,12 +116,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -129,12 +129,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -142,16 +142,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
@@ -159,16 +159,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "sharp-spearhead",
+                            "qty": 2
                         }
                     ]
                 },
@@ -176,16 +176,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "sharp-spearhead",
+                            "qty": 5
                         }
                     ]
                 },
@@ -193,16 +193,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -245,16 +245,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 8
+                            "item": "gold",
+                            "qty": 60000
                         },
                         {
                             "item": "molagora",
                             "qty": 5
                         },
                         {
-                            "item": "gold",
-                            "qty": 60000
+                            "item": "sharp-spearhead",
+                            "qty": 8
                         }
                     ]
                 }
@@ -297,12 +297,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -310,25 +310,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -336,16 +336,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
@@ -353,33 +353,33 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "sharp-spearhead",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 5
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 45000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 5
                         }
                     ]
                 },
@@ -387,16 +387,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -472,6 +472,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/kikirat-v2.json
+++ b/src/hero/kikirat-v2.json
@@ -92,12 +92,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -105,12 +105,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -118,16 +118,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "slime-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -135,16 +135,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "slime-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -152,16 +152,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "slime-jelly",
+                            "qty": 5
                         }
                     ]
                 }
@@ -212,12 +212,12 @@
                     "description": "+0.5% Defense",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -225,12 +225,12 @@
                     "description": "+0.5% Defense",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -238,16 +238,16 @@
                     "description": "+0.5% Defense",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "slime-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -255,16 +255,16 @@
                     "description": "+0.5% Defense",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "slime-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -272,16 +272,16 @@
                     "description": "+1% Defense",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "slime-jelly",
+                            "qty": 5
                         }
                     ]
                 }
@@ -322,12 +322,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -335,12 +335,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -348,16 +348,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "slime-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -365,16 +365,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "slime-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -382,16 +382,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "slime-jelly",
+                            "qty": 5
                         }
                     ]
                 }
@@ -453,6 +453,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/kiris.json
+++ b/src/hero/kiris.json
@@ -100,12 +100,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -113,12 +113,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -126,12 +126,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -139,16 +139,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "slime-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -156,16 +156,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 28000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 28000
+                            "item": "slime-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -173,16 +173,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "slime-jelly",
+                            "qty": 5
                         }
                     ]
                 },
@@ -190,16 +190,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "slime-jelly",
+                            "qty": 6
                         }
                     ]
                 }
@@ -242,12 +242,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -255,12 +255,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -268,16 +268,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "slime-jelly",
+                            "qty": 1
                         }
                     ]
                 },
@@ -285,16 +285,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "slime-jelly",
+                            "qty": 2
                         }
                     ]
                 },
@@ -302,16 +302,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "slime-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -319,16 +319,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "slime-jelly",
+                            "qty": 6
                         }
                     ]
                 }
@@ -369,16 +369,16 @@
                     "description": "+2 Soul acquired",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 14000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 14000
+                            "item": "slime-jelly",
+                            "qty": 2
                         }
                     ]
                 },
@@ -386,16 +386,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 35000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 35000
+                            "item": "slime-jelly",
+                            "qty": 3
                         }
                     ]
                 }
@@ -469,6 +469,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/kise.json
+++ b/src/hero/kise.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,29 +117,29 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "twisted-fang",
-                            "qty": 5
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 33000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "twisted-fang",
+                            "qty": 7
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -214,12 +214,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -227,12 +227,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -240,16 +240,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 },
@@ -257,16 +257,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "twisted-fang",
+                            "qty": 7
                         }
                     ]
                 },
@@ -274,16 +274,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -324,12 +324,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -337,12 +337,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -350,16 +350,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 },
@@ -367,16 +367,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "twisted-fang",
+                            "qty": 7
                         }
                     ]
                 },
@@ -384,16 +384,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -469,6 +469,7 @@
         "east": false,
         "west": false
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/kitty-clarissa.json
+++ b/src/hero/kitty-clarissa.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,25 +117,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -143,16 +143,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "flame-of-soul",
+                            "qty": 1
                         }
                     ]
                 },
@@ -160,33 +160,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "flame-of-soul",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "flame-of-soul",
-                            "qty": 5
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 45000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "flame-of-soul",
+                            "qty": 5
                         }
                     ]
                 },
@@ -194,16 +194,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "demon-blood-gem",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "demon-blood-gem",
+                            "qty": 2
                         }
                     ]
                 }
@@ -254,12 +254,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -267,12 +267,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -280,12 +280,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -293,16 +293,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "flame-of-soul",
+                            "qty": 1
                         }
                     ]
                 },
@@ -310,16 +310,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "flame-of-soul",
+                            "qty": 2
                         }
                     ]
                 },
@@ -327,16 +327,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "flame-of-soul",
+                            "qty": 5
                         }
                     ]
                 },
@@ -344,16 +344,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "demon-blood-gem",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "demon-blood-gem",
+                            "qty": 2
                         }
                     ]
                 }
@@ -396,16 +396,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 8
+                            "item": "gold",
+                            "qty": 60000
                         },
                         {
                             "item": "molagora",
                             "qty": 5
                         },
                         {
-                            "item": "gold",
-                            "qty": 60000
+                            "item": "flame-of-soul",
+                            "qty": 8
                         }
                     ]
                 }
@@ -482,6 +482,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "dac",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/kluri.json
+++ b/src/hero/kluri.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+5% Combat Readiness",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "path-power-loop",
+                            "qty": 1
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "path-power-loop",
+                            "qty": 2
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "path-power-loop",
+                            "qty": 4
                         }
                     ]
                 },
@@ -181,16 +181,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "path-power-loop",
+                            "qty": 6
                         }
                     ]
                 }
@@ -241,12 +241,12 @@
                     "description": "+0.5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -254,46 +254,29 @@
                     "description": "+0.5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+1% healing",
                     "resources": [
-                        {
-                            "item": "path-power-loop",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 13000
-                        }
-                    ]
-                },
-                {
-                    "description": "+1% healing",
-                    "resources": [
-                        {
-                            "item": "path-power-loop",
-                            "qty": 2
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "path-power-loop",
+                            "qty": 1
                         }
                     ]
                 },
@@ -301,16 +284,33 @@
                     "description": "+1% healing",
                     "resources": [
                         {
+                            "item": "gold",
+                            "qty": 18000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
                             "item": "path-power-loop",
-                            "qty": 4
+                            "qty": 2
+                        }
+                    ]
+                },
+                {
+                    "description": "+1% healing",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "path-power-loop",
+                            "qty": 4
                         }
                     ]
                 },
@@ -318,16 +318,16 @@
                     "description": "+1% healing",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "path-power-loop",
+                            "qty": 6
                         }
                     ]
                 }
@@ -368,16 +368,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 14000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 14000
+                            "item": "path-power-loop",
+                            "qty": 2
                         }
                     ]
                 },
@@ -385,16 +385,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "path-power-loop",
+                            "qty": 3
                         }
                     ]
                 },
@@ -402,16 +402,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "path-power-loop",
+                            "qty": 5
                         }
                     ]
                 }
@@ -488,6 +488,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "def",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/krau.json
+++ b/src/hero/krau.json
@@ -108,12 +108,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -121,12 +121,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -134,16 +134,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "strange-jelly",
+                            "qty": 2
                         }
                     ]
                 },
@@ -151,16 +151,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 36000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 36000
+                            "item": "strange-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -168,16 +168,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "strange-jelly",
+                            "qty": 5
                         }
                     ]
                 },
@@ -185,16 +185,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "ancient-creature-nucleus",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "ancient-creature-nucleus",
+                            "qty": 2
                         }
                     ]
                 }
@@ -247,12 +247,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -260,12 +260,12 @@
                     "description": "+5% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -273,12 +273,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -286,16 +286,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "strange-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -303,33 +303,33 @@
                     "description": "+10% Combat Readiness",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "strange-jelly",
+                            "qty": 4
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "strange-jelly",
-                            "qty": 7
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 55000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "strange-jelly",
+                            "qty": 7
                         }
                     ]
                 },
@@ -337,16 +337,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "ancient-creature-nucleus",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 110000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 110000
+                            "item": "ancient-creature-nucleus",
+                            "qty": 3
                         }
                     ]
                 }
@@ -399,16 +399,16 @@
                     "description": "+2 soul acquired",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "strange-jelly",
+                            "qty": 5
                         }
                     ]
                 },
@@ -416,16 +416,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "ancient-creature-nucleus",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "ancient-creature-nucleus",
+                            "qty": 2
                         }
                     ]
                 }
@@ -501,6 +501,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/leo.json
+++ b/src/hero/leo.json
@@ -104,25 +104,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% effect chance",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "slime-jelly",
+                            "qty": 1
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "slime-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "dragons-wrath",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "dragons-wrath",
+                            "qty": 2
                         }
                     ]
                 }
@@ -216,12 +216,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -229,12 +229,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -242,16 +242,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "slime-jelly",
+                            "qty": 1
                         }
                     ]
                 },
@@ -259,16 +259,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "slime-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -276,16 +276,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "dragons-wrath",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "dragons-wrath",
+                            "qty": 2
                         }
                     ]
                 }
@@ -328,12 +328,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -341,12 +341,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -354,16 +354,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "slime-jelly",
+                            "qty": 1
                         }
                     ]
                 },
@@ -371,16 +371,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "slime-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -388,16 +388,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "dragons-wrath",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "dragons-wrath",
+                            "qty": 2
                         }
                     ]
                 }
@@ -474,6 +474,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/lidica.json
+++ b/src/hero/lidica.json
@@ -112,25 +112,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -138,16 +138,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "flame-of-soul",
+                            "qty": 5
                         }
                     ]
                 },
@@ -155,16 +155,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "flame-of-soul",
+                            "qty": 7
                         }
                     ]
                 },
@@ -172,16 +172,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "demon-blood-gem",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "demon-blood-gem",
+                            "qty": 2
                         }
                     ]
                 }
@@ -222,12 +222,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -235,12 +235,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -248,16 +248,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "flame-of-soul",
+                            "qty": 5
                         }
                     ]
                 },
@@ -265,16 +265,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "flame-of-soul",
+                            "qty": 7
                         }
                     ]
                 },
@@ -282,16 +282,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "demon-blood-gem",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "demon-blood-gem",
+                            "qty": 2
                         }
                     ]
                 }
@@ -334,12 +334,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -347,12 +347,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -360,16 +360,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "flame-of-soul",
+                            "qty": 5
                         }
                     ]
                 },
@@ -377,16 +377,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "flame-of-soul",
+                            "qty": 7
                         }
                     ]
                 },
@@ -394,16 +394,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "demon-blood-gem",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "demon-blood-gem",
+                            "qty": 2
                         }
                     ]
                 }
@@ -481,6 +481,7 @@
         "east": false,
         "west": false
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/lorina.json
+++ b/src/hero/lorina.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 }
@@ -214,12 +214,12 @@
                     "description": "+0.5% Attack",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -227,12 +227,12 @@
                     "description": "+0.5% Attack",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -240,16 +240,16 @@
                     "description": "+1% Attack",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -257,16 +257,16 @@
                     "description": "+1% Attack",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 },
@@ -274,16 +274,16 @@
                     "description": "+2% Attack",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 }
@@ -324,12 +324,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -337,12 +337,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -350,16 +350,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -367,16 +367,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 },
@@ -384,16 +384,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 }
@@ -467,6 +467,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/lots.json
+++ b/src/hero/lots.json
@@ -108,12 +108,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -121,12 +121,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -134,16 +134,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "ring-of-glory",
+                            "qty": 1
                         }
                     ]
                 },
@@ -151,16 +151,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -168,16 +168,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -220,12 +220,12 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -233,12 +233,12 @@
                     "description": "+5% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -246,16 +246,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "ring-of-glory",
+                            "qty": 1
                         }
                     ]
                 },
@@ -263,16 +263,16 @@
                     "description": "+5% Combat Readiness",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -280,16 +280,16 @@
                     "description": "+10% Combat Readiness",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -330,12 +330,12 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -343,12 +343,12 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -356,33 +356,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "ring-of-glory",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+3% Combat Readiness",
                     "resources": [
-                        {
-                            "item": "ring-of-glory",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -390,16 +390,16 @@
                     "description": "+3% Combat Readiness",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -475,6 +475,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "dac",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/ludwig.json
+++ b/src/hero/ludwig.json
@@ -108,12 +108,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -121,12 +121,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -134,16 +134,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 },
@@ -151,16 +151,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "twisted-fang",
+                            "qty": 7
                         }
                     ]
                 },
@@ -168,16 +168,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -218,12 +218,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -231,12 +231,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -244,16 +244,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 },
@@ -261,16 +261,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "twisted-fang",
+                            "qty": 7
                         }
                     ]
                 },
@@ -278,16 +278,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -332,12 +332,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -345,12 +345,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -358,16 +358,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 },
@@ -375,16 +375,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "twisted-fang",
+                            "qty": 7
                         }
                     ]
                 },
@@ -392,16 +392,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -477,6 +477,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/luluca.json
+++ b/src/hero/luluca.json
@@ -108,25 +108,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -134,16 +134,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "leather-sheath",
+                            "qty": 5
                         }
                     ]
                 },
@@ -151,16 +151,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "leather-sheath",
+                            "qty": 7
                         }
                     ]
                 },
@@ -168,16 +168,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "fighter-medal",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "fighter-medal",
+                            "qty": 2
                         }
                     ]
                 }
@@ -218,12 +218,12 @@
                     "description": "+5% barrier strength",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -231,12 +231,12 @@
                     "description": "+5% barrier strength",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -244,16 +244,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "leather-sheath",
+                            "qty": 5
                         }
                     ]
                 },
@@ -261,16 +261,16 @@
                     "description": "+5% barrier strength",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "leather-sheath",
+                            "qty": 7
                         }
                     ]
                 },
@@ -278,16 +278,16 @@
                     "description": "+10% barrier strength",
                     "resources": [
                         {
-                            "item": "fighter-medal",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "fighter-medal",
+                            "qty": 2
                         }
                     ]
                 }
@@ -331,12 +331,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -344,12 +344,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -357,16 +357,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "leather-sheath",
+                            "qty": 5
                         }
                     ]
                 },
@@ -374,16 +374,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "leather-sheath",
+                            "qty": 7
                         }
                     ]
                 },
@@ -391,16 +391,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "fighter-medal",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "fighter-medal",
+                            "qty": 2
                         }
                     ]
                 }
@@ -476,6 +476,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/luna.json
+++ b/src/hero/luna.json
@@ -104,25 +104,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "mysterious-flash",
+                            "qty": 5
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "mysterious-flash",
+                            "qty": 7
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "reingar-student-id",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "reingar-student-id",
+                            "qty": 2
                         }
                     ]
                 }
@@ -214,25 +214,25 @@
                     "description": "+1% all stats",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+2% all stats",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -240,16 +240,16 @@
                     "description": "+2% all stats",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "mysterious-flash",
+                            "qty": 5
                         }
                     ]
                 },
@@ -257,16 +257,16 @@
                     "description": "+2% all stats",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "mysterious-flash",
+                            "qty": 7
                         }
                     ]
                 },
@@ -274,16 +274,16 @@
                     "description": "+3% all stats",
                     "resources": [
                         {
-                            "item": "reingar-student-id",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "reingar-student-id",
+                            "qty": 2
                         }
                     ]
                 }
@@ -324,12 +324,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -337,12 +337,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -350,16 +350,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "mysterious-flash",
+                            "qty": 5
                         }
                     ]
                 },
@@ -367,16 +367,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "mysterious-flash",
+                            "qty": 7
                         }
                     ]
                 },
@@ -384,16 +384,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "reingar-student-id",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "reingar-student-id",
+                            "qty": 2
                         }
                     ]
                 }
@@ -469,6 +469,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "chc",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/maid-chloe.json
+++ b/src/hero/maid-chloe.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -130,29 +130,29 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+5% effect chance",
                     "resources": [
-                        {
-                            "item": "flame-of-soul",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "flame-of-soul",
+                            "qty": 3
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "flame-of-soul",
+                            "qty": 4
                         }
                     ]
                 },
@@ -177,16 +177,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 55000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 55000
+                            "item": "flame-of-soul",
+                            "qty": 7
                         }
                     ]
                 },
@@ -194,16 +194,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "demon-blood-gem",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 110000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 110000
+                            "item": "demon-blood-gem",
+                            "qty": 3
                         }
                     ]
                 }
@@ -246,38 +246,25 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% healing",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
-                        }
-                    ]
-                },
-                {
-                    "description": "+5% healing",
-                    "resources": [
+                        },
                         {
                             "item": "molagora",
                             "qty": 2
-                        },
-                        {
-                            "item": "gold",
-                            "qty": 8000
                         }
                     ]
                 },
@@ -285,67 +272,80 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 8000
                         },
                         {
                             "item": "molagora",
-                            "qty": 3
-                        },
+                            "qty": 2
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% healing",
+                    "resources": [
                         {
                             "item": "gold",
                             "qty": 27000
-                        }
-                    ]
-                },
-                {
-                    "description": "+10% healing",
-                    "resources": [
-                        {
-                            "item": "flame-of-soul",
-                            "qty": 4
                         },
                         {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
-                        {
-                            "item": "gold",
-                            "qty": 40000
-                        }
-                    ]
-                },
-                {
-                    "description": "+10% healing",
-                    "resources": [
-                        {
-                            "item": "flame-of-soul",
-                            "qty": 7
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
-                        {
-                            "item": "gold",
-                            "qty": 55000
-                        }
-                    ]
-                },
-                {
-                    "description": "+10% healing",
-                    "resources": [
-                        {
-                            "item": "demon-blood-gem",
+                            "item": "molagora",
                             "qty": 3
                         },
                         {
+                            "item": "flame-of-soul",
+                            "qty": 3
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% healing",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 40000
+                        },
+                        {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
+                            "item": "flame-of-soul",
+                            "qty": 4
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% healing",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 55000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "flame-of-soul",
+                            "qty": 7
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% healing",
+                    "resources": [
+                        {
                             "item": "gold",
                             "qty": 110000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "demon-blood-gem",
+                            "qty": 3
                         }
                     ]
                 }
@@ -386,16 +386,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 8
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "flame-of-soul",
+                            "qty": 8
                         }
                     ]
                 }
@@ -472,6 +472,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "efr",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/martial-artist-ken.json
+++ b/src/hero/martial-artist-ken.json
@@ -91,12 +91,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -117,16 +117,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "twisted-fang",
+                            "qty": 2
                         }
                     ]
                 },
@@ -134,16 +134,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 36000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 36000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 },
@@ -151,16 +151,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 },
@@ -168,16 +168,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -219,16 +219,16 @@
                     "description": "+5% damage dealt by Dragon Flame",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 19000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 19000
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -236,16 +236,16 @@
                     "description": "+10% damage dealt by Dragon Flame",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 },
@@ -253,16 +253,16 @@
                     "description": "+15% damage dealt by Dragon Flame",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 130000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 130000
+                            "item": "blazing-soul",
+                            "qty": 3
                         }
                     ]
                 }
@@ -302,12 +302,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -315,12 +315,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -328,16 +328,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "twisted-fang",
+                            "qty": 2
                         }
                     ]
                 },
@@ -345,16 +345,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 36000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 36000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 },
@@ -362,16 +362,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 },
@@ -379,16 +379,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -466,6 +466,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/mascot-hazel.json
+++ b/src/hero/mascot-hazel.json
@@ -108,12 +108,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -121,16 +121,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "leather-sheath",
+                            "qty": 2
                         }
                     ]
                 },
@@ -138,16 +138,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "leather-sheath",
+                            "qty": 3
                         }
                     ]
                 },
@@ -155,16 +155,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "leather-sheath",
+                            "qty": 4
                         }
                     ]
                 }
@@ -207,29 +207,29 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% healing",
                     "resources": [
-                        {
-                            "item": "leather-sheath",
-                            "qty": 2
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 18000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "leather-sheath",
+                            "qty": 2
                         }
                     ]
                 },
@@ -237,16 +237,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "leather-sheath",
+                            "qty": 3
                         }
                     ]
                 },
@@ -254,16 +254,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "leather-sheath",
+                            "qty": 4
                         }
                     ]
                 }
@@ -304,12 +304,12 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -317,25 +317,25 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% healing",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -343,33 +343,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "leather-sheath",
+                            "qty": 3
                         }
                     ]
                 },
                 {
                     "description": "+10% healing",
                     "resources": [
-                        {
-                            "item": "leather-sheath",
-                            "qty": 4
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 28000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "leather-sheath",
+                            "qty": 4
                         }
                     ]
                 },
@@ -377,16 +377,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "leather-sheath",
+                            "qty": 5
                         }
                     ]
                 },
@@ -394,16 +394,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "leather-sheath",
+                            "qty": 6
                         }
                     ]
                 }
@@ -480,6 +480,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/maya.json
+++ b/src/hero/maya.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "path-power-loop",
+                            "qty": 1
                         }
                     ]
                 },
@@ -147,33 +147,33 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "path-power-loop",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "path-power-loop",
-                            "qty": 4
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 32000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "path-power-loop",
+                            "qty": 4
                         }
                     ]
                 },
@@ -181,16 +181,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "nightmare-mask",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "nightmare-mask",
+                            "qty": 2
                         }
                     ]
                 }
@@ -243,12 +243,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -256,29 +256,29 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% effect chance",
                     "resources": [
-                        {
-                            "item": "path-power-loop",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 13000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "path-power-loop",
+                            "qty": 1
                         }
                     ]
                 },
@@ -286,33 +286,33 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "path-power-loop",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "path-power-loop",
-                            "qty": 4
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 32000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "path-power-loop",
+                            "qty": 4
                         }
                     ]
                 },
@@ -320,16 +320,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "nightmare-mask",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "nightmare-mask",
+                            "qty": 2
                         }
                     ]
                 }
@@ -382,16 +382,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 9000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 9000
+                            "item": "path-power-loop",
+                            "qty": 1
                         }
                     ]
                 },
@@ -399,16 +399,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 31000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 31000
+                            "item": "path-power-loop",
+                            "qty": 3
                         }
                     ]
                 },
@@ -416,16 +416,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "nightmare-mask",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "nightmare-mask",
+                            "qty": 1
                         }
                     ]
                 }
@@ -504,6 +504,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "def",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/mega-phantasma.json
+++ b/src/hero/mega-phantasma.json
@@ -112,6 +112,7 @@
         "east": false,
         "west": false
     },
+    "memoryImprintAttribute": "",
     "memoryImprint": [],
     "awakening": []
 }

--- a/src/hero/mercedes.json
+++ b/src/hero/mercedes.json
@@ -120,25 +120,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -146,33 +146,33 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -180,16 +180,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -230,12 +230,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -243,46 +243,29 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 17000
-                        }
-                    ]
-                },
-                {
-                    "description": "+10% damage dealt",
-                    "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 3
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
@@ -290,16 +273,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 3
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -340,12 +340,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -353,12 +353,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -366,33 +366,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+15% damage dealt",
                     "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -400,16 +400,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -483,6 +483,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/mirsa.json
+++ b/src/hero/mirsa.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -130,33 +130,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "strange-jelly",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% effect chance",
                     "resources": [
-                        {
-                            "item": "strange-jelly",
-                            "qty": 2
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 18000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "strange-jelly",
+                            "qty": 2
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "strange-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -181,16 +181,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "strange-jelly",
+                            "qty": 6
                         }
                     ]
                 }
@@ -243,16 +243,16 @@
                     "description": "+5% Evasion Chance",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 14000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 14000
+                            "item": "strange-jelly",
+                            "qty": 2
                         }
                     ]
                 },
@@ -260,16 +260,16 @@
                     "description": "+5% Evasion Chance",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "strange-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -277,16 +277,16 @@
                     "description": "+5% Evasion Chance",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "strange-jelly",
+                            "qty": 5
                         }
                     ]
                 }
@@ -329,12 +329,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -342,12 +342,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -355,33 +355,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "strange-jelly",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "strange-jelly",
-                            "qty": 2
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 18000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "strange-jelly",
+                            "qty": 2
                         }
                     ]
                 },
@@ -389,16 +389,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "strange-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -406,16 +406,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "strange-jelly",
+                            "qty": 6
                         }
                     ]
                 }
@@ -501,6 +501,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "spd",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/mistychain.json
+++ b/src/hero/mistychain.json
@@ -96,12 +96,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -109,12 +109,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -122,16 +122,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -139,16 +139,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 },
@@ -156,16 +156,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 }
@@ -206,12 +206,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -219,12 +219,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -232,16 +232,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -249,16 +249,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 },
@@ -266,16 +266,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 }
@@ -319,12 +319,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -332,12 +332,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -345,16 +345,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -362,16 +362,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 },
@@ -379,16 +379,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 }
@@ -464,6 +464,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "def",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/montmorancy.json
+++ b/src/hero/montmorancy.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "strange-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "strange-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "strange-jelly",
+                            "qty": 5
                         }
                     ]
                 }
@@ -216,12 +216,12 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -229,12 +229,12 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -242,16 +242,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "strange-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -259,16 +259,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "strange-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -276,16 +276,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "strange-jelly",
+                            "qty": 5
                         }
                     ]
                 }
@@ -326,12 +326,12 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -339,12 +339,12 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -352,16 +352,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "strange-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -369,16 +369,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "strange-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -386,16 +386,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "strange-jelly",
+                            "qty": 5
                         }
                     ]
                 }
@@ -471,6 +471,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "def",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/mucacha.json
+++ b/src/hero/mucacha.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "archers-vision",
+                            "qty": 3
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+3% Combat Readiness",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "archers-vision",
+                            "qty": 4
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "archers-vision",
+                            "qty": 5
                         }
                     ]
                 }
@@ -224,12 +224,12 @@
                     "description": "+0.1% Speed",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -237,12 +237,12 @@
                     "description": "+0.2% Speed",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -250,16 +250,16 @@
                     "description": "+0.2% Speed",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "archers-vision",
+                            "qty": 3
                         }
                     ]
                 },
@@ -267,16 +267,16 @@
                     "description": "+0.2% Speed",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "archers-vision",
+                            "qty": 4
                         }
                     ]
                 },
@@ -284,16 +284,16 @@
                     "description": "+0.3% Speed",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "archers-vision",
+                            "qty": 5
                         }
                     ]
                 }
@@ -334,12 +334,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -347,12 +347,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -360,16 +360,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "archers-vision",
+                            "qty": 3
                         }
                     ]
                 },
@@ -377,16 +377,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "archers-vision",
+                            "qty": 4
                         }
                     ]
                 },
@@ -394,16 +394,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "archers-vision",
+                            "qty": 5
                         }
                     ]
                 }
@@ -491,6 +491,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "spd",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/nemunas.json
+++ b/src/hero/nemunas.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "mysterious-flash",
+                            "qty": 1
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+3% Combat Readiness",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "mysterious-flash",
+                            "qty": 2
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "mysterious-flash",
+                            "qty": 4
                         }
                     ]
                 },
@@ -181,16 +181,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "mysterious-flash",
+                            "qty": 6
                         }
                     ]
                 }
@@ -231,12 +231,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -244,25 +244,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -270,33 +270,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "mysterious-flash",
-                            "qty": 4
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 28000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "mysterious-flash",
+                            "qty": 4
                         }
                     ]
                 },
@@ -304,16 +304,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "mysterious-flash",
+                            "qty": 5
                         }
                     ]
                 },
@@ -321,16 +321,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "mysterious-flash",
+                            "qty": 6
                         }
                     ]
                 }
@@ -383,16 +383,16 @@
                     "description": "+2 Soul acquired",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 14000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 14000
+                            "item": "mysterious-flash",
+                            "qty": 2
                         }
                     ]
                 },
@@ -400,16 +400,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 35000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 35000
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 }
@@ -485,6 +485,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/nilgal.json
+++ b/src/hero/nilgal.json
@@ -210,6 +210,7 @@
         "east": false,
         "west": false
     },
+    "memoryImprintAttribute": "",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/otillie.json
+++ b/src/hero/otillie.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "shiny-enchantment",
+                            "qty": 3
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "shiny-enchantment",
+                            "qty": 4
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "shiny-enchantment",
+                            "qty": 5
                         }
                     ]
                 }
@@ -215,12 +215,12 @@
                     "description": "-0.5% damage received",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -228,12 +228,12 @@
                     "description": "-0.5% damage received",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -241,16 +241,16 @@
                     "description": "-1% damage received",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "shiny-enchantment",
+                            "qty": 3
                         }
                     ]
                 },
@@ -258,16 +258,16 @@
                     "description": "-1% damage received",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "shiny-enchantment",
+                            "qty": 4
                         }
                     ]
                 },
@@ -275,16 +275,16 @@
                     "description": "-2% damage received",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "shiny-enchantment",
+                            "qty": 5
                         }
                     ]
                 }
@@ -324,12 +324,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -337,12 +337,12 @@
                     "description": "+5% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -350,16 +350,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "shiny-enchantment",
+                            "qty": 3
                         }
                     ]
                 },
@@ -367,16 +367,16 @@
                     "description": "+10% Combat Readiness",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "shiny-enchantment",
+                            "qty": 4
                         }
                     ]
                 },
@@ -384,16 +384,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "shiny-enchantment",
+                            "qty": 5
                         }
                     ]
                 }
@@ -469,6 +469,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "def",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/pearlhorizon.json
+++ b/src/hero/pearlhorizon.json
@@ -96,12 +96,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -109,12 +109,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -122,16 +122,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "shiny-enchantment",
+                            "qty": 1
                         }
                     ]
                 },
@@ -139,16 +139,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "shiny-enchantment",
+                            "qty": 2
                         }
                     ]
                 },
@@ -156,16 +156,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "shiny-enchantment",
+                            "qty": 4
                         }
                     ]
                 },
@@ -173,16 +173,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "shiny-enchantment",
+                            "qty": 6
                         }
                     ]
                 }
@@ -225,16 +225,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 14000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 14000
+                            "item": "shiny-enchantment",
+                            "qty": 2
                         }
                     ]
                 },
@@ -242,16 +242,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "shiny-enchantment",
+                            "qty": 3
                         }
                     ]
                 },
@@ -259,16 +259,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "shiny-enchantment",
+                            "qty": 5
                         }
                     ]
                 }
@@ -311,12 +311,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -324,12 +324,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -337,33 +337,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "shiny-enchantment",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "shiny-enchantment",
-                            "qty": 2
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 18000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "shiny-enchantment",
+                            "qty": 2
                         }
                     ]
                 },
@@ -371,16 +371,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "shiny-enchantment",
+                            "qty": 4
                         }
                     ]
                 },
@@ -388,16 +388,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "shiny-enchantment",
+                            "qty": 6
                         }
                     ]
                 }
@@ -473,6 +473,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/purrgis.json
+++ b/src/hero/purrgis.json
@@ -108,12 +108,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -121,12 +121,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -134,16 +134,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
@@ -151,16 +151,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -168,16 +168,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -220,42 +220,42 @@
                     "description": "+1% counterattack chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+2% counterattack chance",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+2% counterattack chance",
                     "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 17000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
@@ -263,16 +263,16 @@
                     "description": "+2% counterattack chance",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -280,16 +280,16 @@
                     "description": "+3% counterattack chance",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -330,12 +330,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -343,12 +343,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -356,33 +356,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -390,16 +390,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -475,6 +475,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/pyllis.json
+++ b/src/hero/pyllis.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "baby-mouse-insignia",
+                            "qty": 3
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "baby-mouse-insignia",
+                            "qty": 4
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "baby-mouse-insignia",
+                            "qty": 5
                         }
                     ]
                 }
@@ -226,12 +226,12 @@
                     "description": "+10% additional defense increase when attacked",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -239,12 +239,12 @@
                     "description": "+10% additional defense increase when attacked",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -252,16 +252,16 @@
                     "description": "+10% additional defense increase when attacked",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "baby-mouse-insignia",
+                            "qty": 3
                         }
                     ]
                 },
@@ -269,16 +269,16 @@
                     "description": "+10% additional defense increase when attacked",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "baby-mouse-insignia",
+                            "qty": 4
                         }
                     ]
                 },
@@ -286,16 +286,16 @@
                     "description": "+10% additional defense increase when attacked",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "baby-mouse-insignia",
+                            "qty": 5
                         }
                     ]
                 }
@@ -338,12 +338,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -351,12 +351,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -364,16 +364,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "baby-mouse-insignia",
+                            "qty": 3
                         }
                     ]
                 },
@@ -381,16 +381,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "baby-mouse-insignia",
+                            "qty": 4
                         }
                     ]
                 },
@@ -398,16 +398,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "baby-mouse-insignia",
+                            "qty": 5
                         }
                     ]
                 }
@@ -493,6 +493,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "def",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/ras.json
+++ b/src/hero/ras.json
@@ -120,12 +120,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -133,12 +133,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -146,16 +146,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 },
@@ -163,16 +163,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "mysterious-flash",
+                            "qty": 4
                         }
                     ]
                 },
@@ -180,16 +180,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "mysterious-flash",
+                            "qty": 5
                         }
                     ]
                 }
@@ -240,12 +240,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -253,12 +253,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -266,16 +266,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 },
@@ -283,16 +283,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "mysterious-flash",
+                            "qty": 4
                         }
                     ]
                 },
@@ -300,16 +300,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "mysterious-flash",
+                            "qty": 5
                         }
                     ]
                 }
@@ -350,12 +350,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -363,12 +363,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -376,16 +376,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 },
@@ -393,16 +393,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "mysterious-flash",
+                            "qty": 4
                         }
                     ]
                 },
@@ -410,16 +410,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "mysterious-flash",
+                            "qty": 5
                         }
                     ]
                 }
@@ -505,6 +505,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/ravi.json
+++ b/src/hero/ravi.json
@@ -92,12 +92,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -105,12 +105,12 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -118,16 +118,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "slime-jelly",
+                            "qty": 5
                         }
                     ]
                 },
@@ -135,16 +135,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "slime-jelly",
+                            "qty": 7
                         }
                     ]
                 },
@@ -152,16 +152,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "dragons-wrath",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "dragons-wrath",
+                            "qty": 2
                         }
                     ]
                 }
@@ -202,25 +202,25 @@
                     "description": "+1% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+1% Combat Readiness",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -228,16 +228,16 @@
                     "description": "+1% Combat Readiness",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "slime-jelly",
+                            "qty": 5
                         }
                     ]
                 },
@@ -245,16 +245,16 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "slime-jelly",
+                            "qty": 7
                         }
                     ]
                 },
@@ -262,16 +262,16 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "dragons-wrath",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "dragons-wrath",
+                            "qty": 2
                         }
                     ]
                 }
@@ -312,12 +312,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -325,12 +325,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -338,16 +338,16 @@
                     "description": "Consume -10 Fighting Spirit",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "slime-jelly",
+                            "qty": 5
                         }
                     ]
                 },
@@ -355,16 +355,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "slime-jelly",
+                            "qty": 7
                         }
                     ]
                 },
@@ -372,16 +372,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "dragons-wrath",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "dragons-wrath",
+                            "qty": 2
                         }
                     ]
                 }
@@ -457,6 +457,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/requiemroar.json
+++ b/src/hero/requiemroar.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "archers-vision",
+                            "qty": 3
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "archers-vision",
+                            "qty": 4
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "archers-vision",
+                            "qty": 5
                         }
                     ]
                 }
@@ -216,12 +216,12 @@
                     "description": "+0.5% Healing relative to damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -229,12 +229,12 @@
                     "description": "+0.5% Healing relative to damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -242,16 +242,16 @@
                     "description": "+1% Healing relative to damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "archers-vision",
+                            "qty": 3
                         }
                     ]
                 },
@@ -259,16 +259,16 @@
                     "description": "+1% Healing relative to damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "archers-vision",
+                            "qty": 4
                         }
                     ]
                 },
@@ -276,16 +276,16 @@
                     "description": "+2% Healing relative to damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "archers-vision",
+                            "qty": 5
                         }
                     ]
                 }
@@ -326,12 +326,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -339,12 +339,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -352,16 +352,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "archers-vision",
+                            "qty": 3
                         }
                     ]
                 },
@@ -369,16 +369,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "archers-vision",
+                            "qty": 4
                         }
                     ]
                 },
@@ -386,16 +386,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "archers-vision",
+                            "qty": 5
                         }
                     ]
                 }
@@ -471,6 +471,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/righteous-thief-roozid.json
+++ b/src/hero/righteous-thief-roozid.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "ring-of-glory",
+                            "qty": 4
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 }
@@ -226,12 +226,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -239,12 +239,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -252,16 +252,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -269,16 +269,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "ring-of-glory",
+                            "qty": 4
                         }
                     ]
                 },
@@ -286,16 +286,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 }
@@ -348,12 +348,12 @@
                     "description": "+1% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -361,12 +361,12 @@
                     "description": "+1% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -374,16 +374,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -391,16 +391,16 @@
                     "description": "+1% Combat Readiness",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "ring-of-glory",
+                            "qty": 4
                         }
                     ]
                 },
@@ -408,16 +408,16 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 }
@@ -494,6 +494,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "spd",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/rikoris.json
+++ b/src/hero/rikoris.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "mysterious-flash",
+                            "qty": 1
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "mysterious-flash",
+                            "qty": 2
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "mysterious-flash",
+                            "qty": 4
                         }
                     ]
                 },
@@ -181,16 +181,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "mysterious-flash",
+                            "qty": 6
                         }
                     ]
                 }
@@ -233,16 +233,16 @@
                     "description": "Acquire +1 Soul",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 14000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 14000
+                            "item": "mysterious-flash",
+                            "qty": 2
                         }
                     ]
                 },
@@ -250,16 +250,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 35000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 35000
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 }
@@ -302,12 +302,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -315,12 +315,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -328,29 +328,29 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% effect chance",
                     "resources": [
-                        {
-                            "item": "mysterious-flash",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 23000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 },
@@ -358,16 +358,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 28000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 28000
+                            "item": "mysterious-flash",
+                            "qty": 4
                         }
                     ]
                 },
@@ -375,16 +375,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "mysterious-flash",
+                            "qty": 5
                         }
                     ]
                 },
@@ -392,16 +392,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "mysterious-flash",
+                            "qty": 6
                         }
                     ]
                 }
@@ -475,6 +475,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "def",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/rima.json
+++ b/src/hero/rima.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,46 +117,29 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "leather-sheath",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 13000
-                        }
-                    ]
-                },
-                {
-                    "description": "+10% damage dealt",
-                    "resources": [
-                        {
-                            "item": "leather-sheath",
-                            "qty": 2
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "leather-sheath",
+                            "qty": 1
                         }
                     ]
                 },
@@ -164,16 +147,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
+                            "item": "gold",
+                            "qty": 18000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
                             "item": "leather-sheath",
-                            "qty": 4
+                            "qty": 2
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "leather-sheath",
+                            "qty": 4
                         }
                     ]
                 },
@@ -181,16 +181,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "leather-sheath",
+                            "qty": 6
                         }
                     ]
                 }
@@ -231,12 +231,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -244,12 +244,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -257,12 +257,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -270,16 +270,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "leather-sheath",
+                            "qty": 3
                         }
                     ]
                 },
@@ -287,16 +287,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 28000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 28000
+                            "item": "leather-sheath",
+                            "qty": 4
                         }
                     ]
                 },
@@ -304,16 +304,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "leather-sheath",
+                            "qty": 5
                         }
                     ]
                 },
@@ -321,16 +321,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "leather-sheath",
+                            "qty": 6
                         }
                     ]
                 }
@@ -373,16 +373,16 @@
                     "description": "Acquire +1 Soul",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 14000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 14000
+                            "item": "leather-sheath",
+                            "qty": 2
                         }
                     ]
                 },
@@ -390,16 +390,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 35000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 35000
+                            "item": "leather-sheath",
+                            "qty": 3
                         }
                     ]
                 }
@@ -473,6 +473,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "def",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/rin.json
+++ b/src/hero/rin.json
@@ -100,42 +100,42 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "flame-of-soul",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 13000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "flame-of-soul",
+                            "qty": 1
                         }
                     ]
                 },
@@ -143,33 +143,33 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "flame-of-soul",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "flame-of-soul",
-                            "qty": 4
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 32000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "flame-of-soul",
+                            "qty": 4
                         }
                     ]
                 },
@@ -177,16 +177,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "demon-blood-gem",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "demon-blood-gem",
+                            "qty": 2
                         }
                     ]
                 }
@@ -237,12 +237,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -250,12 +250,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -263,16 +263,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "flame-of-soul",
+                            "qty": 1
                         }
                     ]
                 },
@@ -280,33 +280,33 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "flame-of-soul",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "flame-of-soul",
-                            "qty": 4
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 32000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "flame-of-soul",
+                            "qty": 4
                         }
                     ]
                 },
@@ -314,16 +314,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "demon-blood-gem",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "demon-blood-gem",
+                            "qty": 2
                         }
                     ]
                 }
@@ -376,16 +376,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 9000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 9000
+                            "item": "flame-of-soul",
+                            "qty": 1
                         }
                     ]
                 },
@@ -393,16 +393,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 31000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 31000
+                            "item": "flame-of-soul",
+                            "qty": 3
                         }
                     ]
                 },
@@ -410,16 +410,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "demon-blood-gem",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "demon-blood-gem",
+                            "qty": 1
                         }
                     ]
                 }
@@ -493,6 +493,7 @@
         "east": false,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/romann.json
+++ b/src/hero/romann.json
@@ -96,12 +96,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -109,12 +109,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -122,33 +122,33 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "ring-of-glory",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "ring-of-glory",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -156,16 +156,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -206,12 +206,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -219,12 +219,12 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -232,16 +232,16 @@
                     "description": "+3% Combat Readiness",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "ring-of-glory",
+                            "qty": 1
                         }
                     ]
                 },
@@ -249,16 +249,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -266,16 +266,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -316,12 +316,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -329,12 +329,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -342,33 +342,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "ring-of-glory",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+15% damage dealt",
                     "resources": [
-                        {
-                            "item": "ring-of-glory",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -376,16 +376,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -461,6 +461,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "def",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/roozid.json
+++ b/src/hero/roozid.json
@@ -100,12 +100,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -113,12 +113,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -126,16 +126,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -143,16 +143,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "ring-of-glory",
+                            "qty": 4
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 }
@@ -222,12 +222,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -235,12 +235,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -248,16 +248,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -265,16 +265,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "ring-of-glory",
+                            "qty": 4
                         }
                     ]
                 },
@@ -282,16 +282,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 }
@@ -344,12 +344,12 @@
                     "description": "+1% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -357,12 +357,12 @@
                     "description": "+1% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -370,16 +370,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -387,16 +387,16 @@
                     "description": "+1% Combat Readiness",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "ring-of-glory",
+                            "qty": 4
                         }
                     ]
                 },
@@ -404,16 +404,16 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 }
@@ -489,6 +489,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "spd",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/rose.json
+++ b/src/hero/rose.json
@@ -100,12 +100,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -113,12 +113,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -126,16 +126,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "mysterious-flash",
+                            "qty": 1
                         }
                     ]
                 },
@@ -143,16 +143,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "reingar-student-id",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "reingar-student-id",
+                            "qty": 2
                         }
                     ]
                 }
@@ -224,12 +224,12 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -237,12 +237,12 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -250,33 +250,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "mysterious-flash",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+3% Combat Readiness",
                     "resources": [
-                        {
-                            "item": "mysterious-flash",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 },
@@ -284,16 +284,16 @@
                     "description": "+3% Combat Readiness",
                     "resources": [
                         {
-                            "item": "reingar-student-id",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "reingar-student-id",
+                            "qty": 2
                         }
                     ]
                 }
@@ -336,12 +336,12 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -349,12 +349,12 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -362,33 +362,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "mysterious-flash",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+3% Combat Readiness",
                     "resources": [
-                        {
-                            "item": "mysterious-flash",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 },
@@ -396,16 +396,16 @@
                     "description": "+3% Combat Readiness",
                     "resources": [
                         {
-                            "item": "reingar-student-id",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "reingar-student-id",
+                            "qty": 2
                         }
                     ]
                 }
@@ -481,6 +481,7 @@
         "east": false,
         "west": true
     },
+    "memoryImprintAttribute": "def",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/ruele-of-light.json
+++ b/src/hero/ruele-of-light.json
@@ -108,12 +108,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -121,12 +121,12 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -134,16 +134,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "strange-jelly",
+                            "qty": 2
                         }
                     ]
                 },
@@ -151,16 +151,16 @@
                     "description": "+15% healing",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 36000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 36000
+                            "item": "strange-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -168,16 +168,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "strange-jelly",
+                            "qty": 5
                         }
                     ]
                 },
@@ -185,16 +185,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "ancient-creature-nucleus",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "ancient-creature-nucleus",
+                            "qty": 2
                         }
                     ]
                 }
@@ -235,38 +235,25 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% healing",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
-                        }
-                    ]
-                },
-                {
-                    "description": "+5% healing",
-                    "resources": [
+                        },
                         {
                             "item": "molagora",
                             "qty": 2
-                        },
-                        {
-                            "item": "gold",
-                            "qty": 8000
                         }
                     ]
                 },
@@ -274,33 +261,46 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 8000
                         },
                         {
                             "item": "molagora",
-                            "qty": 3
-                        },
+                            "qty": 2
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% healing",
+                    "resources": [
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "strange-jelly",
+                            "qty": 3
                         }
                     ]
                 },
                 {
                     "description": "+5% healing",
                     "resources": [
-                        {
-                            "item": "strange-jelly",
-                            "qty": 4
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 40000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "strange-jelly",
+                            "qty": 4
                         }
                     ]
                 },
@@ -308,16 +308,16 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 55000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 55000
+                            "item": "strange-jelly",
+                            "qty": 7
                         }
                     ]
                 },
@@ -325,16 +325,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "ancient-creature-nucleus",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 110000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 110000
+                            "item": "ancient-creature-nucleus",
+                            "qty": 3
                         }
                     ]
                 }
@@ -377,16 +377,16 @@
                     "description": "Acquire +1 Soul",
                     "resources": [
                         {
-                            "item": "strange-jelly",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "strange-jelly",
+                            "qty": 5
                         }
                     ]
                 },
@@ -394,16 +394,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "ancient-creature-nucleus",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "ancient-creature-nucleus",
+                            "qty": 2
                         }
                     ]
                 }
@@ -479,6 +479,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "def",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/sage-baal-sezan.json
+++ b/src/hero/sage-baal-sezan.json
@@ -100,12 +100,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -113,12 +113,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -126,16 +126,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "shiny-enchantment",
+                            "qty": 5
                         }
                     ]
                 },
@@ -143,16 +143,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "shiny-enchantment",
+                            "qty": 7
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "horn-of-desire",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "horn-of-desire",
+                            "qty": 2
                         }
                     ]
                 }
@@ -212,12 +212,12 @@
                     "description": "+3% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -225,12 +225,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -238,16 +238,16 @@
                     "description": "+3% Combat Readiness",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "shiny-enchantment",
+                            "qty": 5
                         }
                     ]
                 },
@@ -255,16 +255,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "shiny-enchantment",
+                            "qty": 7
                         }
                     ]
                 },
@@ -272,16 +272,16 @@
                     "description": "+4% Combat Readiness",
                     "resources": [
                         {
-                            "item": "horn-of-desire",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "horn-of-desire",
+                            "qty": 2
                         }
                     ]
                 }
@@ -324,12 +324,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -337,12 +337,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -350,16 +350,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "shiny-enchantment",
+                            "qty": 5
                         }
                     ]
                 },
@@ -367,16 +367,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "shiny-enchantment",
+                            "qty": 7
                         }
                     ]
                 },
@@ -384,16 +384,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "horn-of-desire",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "horn-of-desire",
+                            "qty": 2
                         }
                     ]
                 }
@@ -467,6 +467,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/schuri.json
+++ b/src/hero/schuri.json
@@ -112,12 +112,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -125,12 +125,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -138,33 +138,33 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "twisted-fang",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "twisted-fang",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -172,16 +172,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -224,42 +224,42 @@
                     "description": "+1% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+2% Combat Readiness",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+2% Combat Readiness",
                     "resources": [
-                        {
-                            "item": "twisted-fang",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 17000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "twisted-fang",
+                            "qty": 1
                         }
                     ]
                 },
@@ -267,16 +267,16 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -284,16 +284,16 @@
                     "description": "+3% Combat Readiness",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -334,12 +334,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -347,12 +347,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -360,33 +360,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "twisted-fang",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "twisted-fang",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "twisted-fang",
+                            "qty": 3
                         }
                     ]
                 },
@@ -394,16 +394,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -477,6 +477,7 @@
         "east": false,
         "west": true
     },
+    "memoryImprintAttribute": "spd",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/serila.json
+++ b/src/hero/serila.json
@@ -100,12 +100,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -113,12 +113,12 @@
                     "description": "+1% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -126,16 +126,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "leather-sheath",
+                            "qty": 1
                         }
                     ]
                 },
@@ -143,16 +143,16 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "leather-sheath",
+                            "qty": 3
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "fighter-medal",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fighter-medal",
+                            "qty": 2
                         }
                     ]
                 }
@@ -210,12 +210,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -223,12 +223,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -236,16 +236,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "leather-sheath",
+                            "qty": 1
                         }
                     ]
                 },
@@ -253,16 +253,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "leather-sheath",
+                            "qty": 3
                         }
                     ]
                 },
@@ -270,16 +270,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "fighter-medal",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fighter-medal",
+                            "qty": 2
                         }
                     ]
                 }
@@ -324,12 +324,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -337,12 +337,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -350,16 +350,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "leather-sheath",
+                            "qty": 1
                         }
                     ]
                 },
@@ -367,16 +367,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "leather-sheath",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "leather-sheath",
+                            "qty": 3
                         }
                     ]
                 },
@@ -384,16 +384,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "fighter-medal",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fighter-medal",
+                            "qty": 2
                         }
                     ]
                 }
@@ -469,6 +469,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "eff",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/sez.json
+++ b/src/hero/sez.json
@@ -108,25 +108,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -134,16 +134,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "sharp-spearhead",
+                            "qty": 5
                         }
                     ]
                 },
@@ -151,16 +151,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "sharp-spearhead",
+                            "qty": 7
                         }
                     ]
                 },
@@ -168,16 +168,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -219,25 +219,25 @@
                     "description": "+5% damage dealt by additional skill",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt by additional skill",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -245,16 +245,16 @@
                     "description": "+5% damage dealt by additional skill",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "sharp-spearhead",
+                            "qty": 5
                         }
                     ]
                 },
@@ -262,16 +262,16 @@
                     "description": "+5% damage dealt by additional skill",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "sharp-spearhead",
+                            "qty": 7
                         }
                     ]
                 },
@@ -279,16 +279,16 @@
                     "description": "+10% damage dealt by additional skill",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -330,12 +330,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -343,12 +343,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -356,16 +356,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "sharp-spearhead",
+                            "qty": 5
                         }
                     ]
                 },
@@ -373,16 +373,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "sharp-spearhead",
+                            "qty": 7
                         }
                     ]
                 },
@@ -390,16 +390,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -473,6 +473,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/shadow-rose.json
+++ b/src/hero/shadow-rose.json
@@ -92,12 +92,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -105,12 +105,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -118,16 +118,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "ring-of-glory",
+                            "qty": 1
                         }
                     ]
                 },
@@ -135,16 +135,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -152,16 +152,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -205,12 +205,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -218,46 +218,29 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "ring-of-glory",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 17000
-                        }
-                    ]
-                },
-                {
-                    "description": "+10% damage dealt",
-                    "resources": [
-                        {
-                            "item": "ring-of-glory",
-                            "qty": 3
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "ring-of-glory",
+                            "qty": 1
                         }
                     ]
                 },
@@ -265,16 +248,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 3
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -317,12 +317,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -330,12 +330,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -343,33 +343,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "ring-of-glory",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+15% damage dealt",
                     "resources": [
-                        {
-                            "item": "ring-of-glory",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -377,16 +377,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -460,6 +460,7 @@
         "east": false,
         "west": false
     },
+    "memoryImprintAttribute": "dac",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/shooting-star-achates.json
+++ b/src/hero/shooting-star-achates.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
                         }
                     ]
                 },
@@ -147,33 +147,33 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "baby-mouse-insignia",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "baby-mouse-insignia",
-                            "qty": 4
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 32000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "baby-mouse-insignia",
+                            "qty": 4
                         }
                     ]
                 },
@@ -181,16 +181,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
                         }
                     ]
                 }
@@ -233,16 +233,16 @@
                     "description": "+2 souls acquired",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "baby-mouse-insignia",
+                            "qty": 3
                         }
                     ]
                 },
@@ -250,16 +250,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 1
                         }
                     ]
                 }
@@ -302,12 +302,12 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -315,25 +315,25 @@
                     "description": "+5% healing",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% healing",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -341,16 +341,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "baby-mouse-insignia",
+                            "qty": 1
                         }
                     ]
                 },
@@ -358,33 +358,33 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "baby-mouse-insignia",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% healing",
                     "resources": [
-                        {
-                            "item": "baby-mouse-insignia",
-                            "qty": 5
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 45000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "baby-mouse-insignia",
+                            "qty": 5
                         }
                     ]
                 },
@@ -392,16 +392,16 @@
                     "description": "+10% healing",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
                         }
                     ]
                 }
@@ -475,6 +475,7 @@
         "east": false,
         "west": false
     },
+    "memoryImprintAttribute": "efr",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/sigret.json
+++ b/src/hero/sigret.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "shiny-enchantment",
+                            "qty": 5
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "shiny-enchantment",
+                            "qty": 7
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "horn-of-desire",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "horn-of-desire",
+                            "qty": 2
                         }
                     ]
                 }
@@ -216,12 +216,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -229,12 +229,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -242,16 +242,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "shiny-enchantment",
+                            "qty": 5
                         }
                     ]
                 },
@@ -259,16 +259,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "shiny-enchantment",
+                            "qty": 7
                         }
                     ]
                 },
@@ -276,16 +276,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "horn-of-desire",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "horn-of-desire",
+                            "qty": 2
                         }
                     ]
                 }
@@ -329,12 +329,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -342,12 +342,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -355,16 +355,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "shiny-enchantment",
+                            "qty": 5
                         }
                     ]
                 },
@@ -372,16 +372,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "shiny-enchantment",
+                            "qty": 7
                         }
                     ]
                 },
@@ -389,16 +389,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "horn-of-desire",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "horn-of-desire",
+                            "qty": 2
                         }
                     ]
                 }
@@ -472,6 +472,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/silk.json
+++ b/src/hero/silk.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -130,12 +130,12 @@
                     "description": "+1% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -143,16 +143,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "flame-of-soul",
+                            "qty": 1
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "flame-of-soul",
+                            "qty": 2
                         }
                     ]
                 },
@@ -177,16 +177,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "flame-of-soul",
+                            "qty": 5
                         }
                     ]
                 },
@@ -194,16 +194,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "demon-blood-gem",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "demon-blood-gem",
+                            "qty": 2
                         }
                     ]
                 }
@@ -254,12 +254,12 @@
                     "description": "+5% damage dealt by Automatic Fire",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -267,16 +267,16 @@
                     "description": "+5% damage dealt by Automatic Fire",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "flame-of-soul",
+                            "qty": 1
                         }
                     ]
                 },
@@ -284,16 +284,16 @@
                     "description": "+5% damage dealt by Automatic Fire",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 21000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 21000
+                            "item": "flame-of-soul",
+                            "qty": 1
                         }
                     ]
                 },
@@ -301,16 +301,16 @@
                     "description": "+5% damage dealt by Automatic Fire",
                     "resources": [
                         {
-                            "item": "demon-blood-gem",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "demon-blood-gem",
+                            "qty": 2
                         }
                     ]
                 }
@@ -351,12 +351,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -364,16 +364,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "flame-of-soul",
+                            "qty": 1
                         }
                     ]
                 },
@@ -381,16 +381,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "flame-of-soul",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 21000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 21000
+                            "item": "flame-of-soul",
+                            "qty": 1
                         }
                     ]
                 },
@@ -398,16 +398,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "demon-blood-gem",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "demon-blood-gem",
+                            "qty": 2
                         }
                     ]
                 }
@@ -485,6 +485,7 @@
         "east": true,
         "west": false
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/silver-blade-aramintha.json
+++ b/src/hero/silver-blade-aramintha.json
@@ -100,12 +100,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -113,12 +113,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -126,16 +126,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 },
@@ -143,16 +143,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "ring-of-glory",
+                            "qty": 7
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -212,25 +212,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -238,16 +238,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 },
@@ -255,16 +255,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "ring-of-glory",
+                            "qty": 7
                         }
                     ]
                 },
@@ -272,16 +272,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -322,12 +322,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -335,12 +335,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -348,16 +348,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 },
@@ -365,16 +365,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "ring-of-glory",
+                            "qty": 7
                         }
                     ]
                 },
@@ -382,16 +382,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -468,6 +468,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/sol.json
+++ b/src/hero/sol.json
@@ -104,25 +104,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "archers-vision",
+                            "qty": 5
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "archers-vision",
+                            "qty": 7
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mercenarys-medicine",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "mercenarys-medicine",
+                            "qty": 2
                         }
                     ]
                 }
@@ -214,25 +214,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -240,16 +240,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "archers-vision",
+                            "qty": 5
                         }
                     ]
                 },
@@ -257,16 +257,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "archers-vision",
+                            "qty": 7
                         }
                     ]
                 },
@@ -274,16 +274,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mercenarys-medicine",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "mercenarys-medicine",
+                            "qty": 2
                         }
                     ]
                 }
@@ -326,12 +326,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -339,12 +339,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -352,16 +352,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "archers-vision",
+                            "qty": 5
                         }
                     ]
                 },
@@ -369,16 +369,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "archers-vision",
+                            "qty": 7
                         }
                     ]
                 },
@@ -386,16 +386,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mercenarys-medicine",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "mercenarys-medicine",
+                            "qty": 2
                         }
                     ]
                 }
@@ -471,6 +471,7 @@
         "east": true,
         "west": false
     },
+    "memoryImprintAttribute": "def",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/specimen-sez.json
+++ b/src/hero/specimen-sez.json
@@ -96,25 +96,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -122,16 +122,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "sharp-spearhead",
+                            "qty": 5
                         }
                     ]
                 },
@@ -139,16 +139,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "sharp-spearhead",
+                            "qty": 7
                         }
                     ]
                 },
@@ -156,16 +156,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -208,25 +208,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -234,16 +234,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "sharp-spearhead",
+                            "qty": 5
                         }
                     ]
                 },
@@ -251,16 +251,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "sharp-spearhead",
+                            "qty": 7
                         }
                     ]
                 },
@@ -268,16 +268,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -320,25 +320,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -346,16 +346,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "sharp-spearhead",
+                            "qty": 5
                         }
                     ]
                 },
@@ -363,16 +363,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "sharp-spearhead",
+                            "qty": 7
                         }
                     ]
                 },
@@ -380,16 +380,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -463,6 +463,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/specter-tenebria.json
+++ b/src/hero/specter-tenebria.json
@@ -108,12 +108,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -121,12 +121,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -134,16 +134,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "ring-of-glory",
+                            "qty": 2
                         }
                     ]
                 },
@@ -151,16 +151,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 36000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 36000
+                            "item": "ring-of-glory",
+                            "qty": 4
                         }
                     ]
                 },
@@ -168,16 +168,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 },
@@ -185,16 +185,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -237,16 +237,16 @@
                     "description": "+0.5% all stats",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 19000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 19000
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -254,16 +254,16 @@
                     "description": "+1% all stats",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 },
@@ -271,16 +271,16 @@
                     "description": "+1.5% all stats",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 130000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 130000
+                            "item": "fused-nerve",
+                            "qty": 3
                         }
                     ]
                 }
@@ -321,12 +321,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -334,12 +334,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -347,16 +347,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "ring-of-glory",
+                            "qty": 2
                         }
                     ]
                 },
@@ -364,33 +364,33 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 36000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 36000
+                            "item": "ring-of-glory",
+                            "qty": 4
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "ring-of-glory",
-                            "qty": 5
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 45000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 },
@@ -398,16 +398,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -483,6 +483,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/surin.json
+++ b/src/hero/surin.json
@@ -96,12 +96,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -109,46 +109,29 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "ring-of-glory",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 17000
-                        }
-                    ]
-                },
-                {
-                    "description": "+10% damage dealt",
-                    "resources": [
-                        {
-                            "item": "ring-of-glory",
-                            "qty": 3
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "ring-of-glory",
+                            "qty": 1
                         }
                     ]
                 },
@@ -156,16 +139,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 3
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -208,42 +208,42 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "ring-of-glory",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 17000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 1
                         }
                     ]
                 },
@@ -251,16 +251,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -268,16 +268,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -321,12 +321,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -334,12 +334,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -347,33 +347,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "ring-of-glory",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+15% damage dealt",
                     "resources": [
-                        {
-                            "item": "ring-of-glory",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -381,16 +381,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "fused-nerve",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "fused-nerve",
+                            "qty": 2
                         }
                     ]
                 }
@@ -464,6 +464,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "spd",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/sven.json
+++ b/src/hero/sven.json
@@ -100,12 +100,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -113,16 +113,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "sharp-spearhead",
+                            "qty": 2
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "sharp-spearhead",
+                            "qty": 4
                         }
                     ]
                 }
@@ -197,46 +197,29 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "-1 turn cooldown",
                     "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 2
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 18000
-                        }
-                    ]
-                },
-                {
-                    "description": "-1 turn cooldown",
-                    "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 3
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "sharp-spearhead",
+                            "qty": 2
                         }
                     ]
                 },
@@ -244,16 +227,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
+                            "item": "gold",
+                            "qty": 23000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
                             "item": "sharp-spearhead",
-                            "qty": 4
+                            "qty": 3
+                        }
+                    ]
+                },
+                {
+                    "description": "-1 turn cooldown",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "sharp-spearhead",
+                            "qty": 4
                         }
                     ]
                 }
@@ -297,12 +297,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -310,12 +310,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -323,12 +323,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -336,33 +336,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 4
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 28000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 4
                         }
                     ]
                 },
@@ -370,16 +370,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "sharp-spearhead",
+                            "qty": 5
                         }
                     ]
                 },
@@ -387,16 +387,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "sharp-spearhead",
+                            "qty": 6
                         }
                     ]
                 }
@@ -470,6 +470,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/tamarinne.json
+++ b/src/hero/tamarinne.json
@@ -112,38 +112,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
-                        }
-                    ]
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": [
+                        },
                         {
                             "item": "molagora",
                             "qty": 2
-                        },
-                        {
-                            "item": "gold",
-                            "qty": 8000
                         }
                     ]
                 },
@@ -151,33 +138,46 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 8000
                         },
                         {
                             "item": "molagora",
-                            "qty": 3
-                        },
+                            "qty": 2
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "archers-vision",
+                            "qty": 3
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "archers-vision",
-                            "qty": 4
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 40000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "archers-vision",
+                            "qty": 4
                         }
                     ]
                 },
@@ -185,16 +185,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 55000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 55000
+                            "item": "archers-vision",
+                            "qty": 7
                         }
                     ]
                 },
@@ -202,16 +202,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "mercenarys-medicine",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 110000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 110000
+                            "item": "mercenarys-medicine",
+                            "qty": 3
                         }
                     ]
                 }
@@ -252,12 +252,12 @@
                     "description": "+2% healing / Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -265,12 +265,12 @@
                     "description": "+2% healing / Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -278,46 +278,46 @@
                     "description": "+2% healing / Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+3% healing / Combat Readiness",
                     "resources": [
-                        {
-                            "item": "archers-vision",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "archers-vision",
+                            "qty": 3
                         }
                     ]
                 },
                 {
                     "description": "+3% healing / Combat Readiness",
                     "resources": [
-                        {
-                            "item": "archers-vision",
-                            "qty": 4
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 40000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "archers-vision",
+                            "qty": 4
                         }
                     ]
                 },
@@ -325,16 +325,16 @@
                     "description": "+3% healing / Combat Readiness",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 55000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 55000
+                            "item": "archers-vision",
+                            "qty": 7
                         }
                     ]
                 },
@@ -342,16 +342,16 @@
                     "description": "+5% healing / Combat Readiness",
                     "resources": [
                         {
-                            "item": "mercenarys-medicine",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 110000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 110000
+                            "item": "mercenarys-medicine",
+                            "qty": 3
                         }
                     ]
                 }
@@ -392,16 +392,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 8
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "archers-vision",
+                            "qty": 8
                         }
                     ]
                 }
@@ -444,38 +444,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
-                        }
-                    ]
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": [
+                        },
                         {
                             "item": "molagora",
                             "qty": 2
-                        },
-                        {
-                            "item": "gold",
-                            "qty": 8000
                         }
                     ]
                 },
@@ -483,33 +470,46 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 8000
                         },
                         {
                             "item": "molagora",
-                            "qty": 3
-                        },
+                            "qty": 2
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "archers-vision",
+                            "qty": 3
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "archers-vision",
-                            "qty": 4
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 40000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "archers-vision",
+                            "qty": 4
                         }
                     ]
                 },
@@ -517,16 +517,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 55000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 55000
+                            "item": "archers-vision",
+                            "qty": 7
                         }
                     ]
                 },
@@ -534,16 +534,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "mercenarys-medicine",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 110000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 110000
+                            "item": "mercenarys-medicine",
+                            "qty": 3
                         }
                     ]
                 }
@@ -584,12 +584,12 @@
                     "description": "+2% healing / Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -597,12 +597,12 @@
                     "description": "+2% healing / Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -610,46 +610,46 @@
                     "description": "+2% healing / Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+3% healing / Combat Readiness",
                     "resources": [
-                        {
-                            "item": "archers-vision",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "archers-vision",
+                            "qty": 3
                         }
                     ]
                 },
                 {
                     "description": "+3% healing / Combat Readiness",
                     "resources": [
-                        {
-                            "item": "archers-vision",
-                            "qty": 4
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 40000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "archers-vision",
+                            "qty": 4
                         }
                     ]
                 },
@@ -657,16 +657,16 @@
                     "description": "+3% healing / Combat Readiness",
                     "resources": [
                         {
-                            "item": "archers-vision",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 55000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 55000
+                            "item": "archers-vision",
+                            "qty": 7
                         }
                     ]
                 },
@@ -674,16 +674,16 @@
                     "description": "+5% healing / Combat Readiness",
                     "resources": [
                         {
-                            "item": "mercenarys-medicine",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 110000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 110000
+                            "item": "mercenarys-medicine",
+                            "qty": 3
                         }
                     ]
                 }
@@ -759,6 +759,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/taranor-guard.json
+++ b/src/hero/taranor-guard.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "mysterious-flash",
+                            "qty": 4
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "mysterious-flash",
+                            "qty": 5
                         }
                     ]
                 }
@@ -216,12 +216,12 @@
                     "description": "+1% Dual Attack chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -229,12 +229,12 @@
                     "description": "+1% Dual Attack chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -242,16 +242,16 @@
                     "description": "+1% Dual Attack chance",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 },
@@ -259,16 +259,16 @@
                     "description": "+1% Dual Attack chance",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "mysterious-flash",
+                            "qty": 4
                         }
                     ]
                 },
@@ -276,16 +276,16 @@
                     "description": "+1% Dual Attack chance",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "mysterious-flash",
+                            "qty": 5
                         }
                     ]
                 }
@@ -328,12 +328,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -341,12 +341,12 @@
                     "description": "+10% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -354,16 +354,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "mysterious-flash",
+                            "qty": 3
                         }
                     ]
                 },
@@ -371,16 +371,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "mysterious-flash",
+                            "qty": 4
                         }
                     ]
                 },
@@ -388,16 +388,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "mysterious-flash",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "mysterious-flash",
+                            "qty": 5
                         }
                     ]
                 }
@@ -471,6 +471,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "def",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/taranor-royal-guard.json
+++ b/src/hero/taranor-royal-guard.json
@@ -100,12 +100,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -113,12 +113,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -126,16 +126,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -143,16 +143,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "sharp-spearhead",
+                            "qty": 4
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "sharp-spearhead",
+                            "qty": 5
                         }
                     ]
                 }
@@ -222,12 +222,12 @@
                     "description": "+2% deflected damage",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -235,12 +235,12 @@
                     "description": "+3% deflected damage",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -248,16 +248,16 @@
                     "description": "+5% deflected damage",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -265,16 +265,16 @@
                     "description": "+5% deflected damage",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "sharp-spearhead",
+                            "qty": 4
                         }
                     ]
                 },
@@ -282,16 +282,16 @@
                     "description": "+5% deflected damage",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "sharp-spearhead",
+                            "qty": 5
                         }
                     ]
                 }
@@ -332,12 +332,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -345,12 +345,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -358,16 +358,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -375,16 +375,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "sharp-spearhead",
+                            "qty": 4
                         }
                     ]
                 },
@@ -392,16 +392,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "sharp-spearhead",
+                            "qty": 5
                         }
                     ]
                 }
@@ -485,6 +485,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/tenebria.json
+++ b/src/hero/tenebria.json
@@ -108,12 +108,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -121,12 +121,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -134,16 +134,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "baby-mouse-insignia",
+                            "qty": 5
                         }
                     ]
                 },
@@ -151,16 +151,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "baby-mouse-insignia",
+                            "qty": 7
                         }
                     ]
                 },
@@ -168,16 +168,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
                         }
                     ]
                 }
@@ -220,12 +220,12 @@
                     "description": "+5% damage dealt ",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -233,12 +233,12 @@
                     "description": "+5% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -246,16 +246,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "baby-mouse-insignia",
+                            "qty": 5
                         }
                     ]
                 },
@@ -263,16 +263,16 @@
                     "description": "+5% Combat Readiness",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "baby-mouse-insignia",
+                            "qty": 7
                         }
                     ]
                 },
@@ -280,16 +280,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
                         }
                     ]
                 }
@@ -330,12 +330,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -343,12 +343,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -356,16 +356,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "baby-mouse-insignia",
+                            "qty": 5
                         }
                     ]
                 },
@@ -373,16 +373,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "baby-mouse-insignia",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "baby-mouse-insignia",
+                            "qty": 7
                         }
                     ]
                 },
@@ -390,16 +390,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "the-heart-of-hypocrisy",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "the-heart-of-hypocrisy",
+                            "qty": 2
                         }
                     ]
                 }
@@ -477,6 +477,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "chc",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/tera-phantasma.json
+++ b/src/hero/tera-phantasma.json
@@ -112,6 +112,7 @@
         "east": false,
         "west": false
     },
+    "memoryImprintAttribute": "",
     "memoryImprint": [],
     "awakening": []
 }

--- a/src/hero/tieria.json
+++ b/src/hero/tieria.json
@@ -92,12 +92,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -105,16 +105,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "path-power-loop",
+                            "qty": 2
                         }
                     ]
                 },
@@ -122,16 +122,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "path-power-loop",
+                            "qty": 3
                         }
                     ]
                 },
@@ -139,16 +139,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "path-power-loop",
+                            "qty": 4
                         }
                     ]
                 }
@@ -191,29 +191,29 @@
                     "description": "+1% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+1% Combat Readiness",
                     "resources": [
-                        {
-                            "item": "path-power-loop",
-                            "qty": 2
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 18000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "path-power-loop",
+                            "qty": 2
                         }
                     ]
                 },
@@ -221,16 +221,16 @@
                     "description": "+1% Combat Readiness",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "path-power-loop",
+                            "qty": 3
                         }
                     ]
                 },
@@ -238,16 +238,16 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "path-power-loop",
+                            "qty": 4
                         }
                     ]
                 }
@@ -288,12 +288,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -301,12 +301,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -314,12 +314,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -327,33 +327,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "path-power-loop",
+                            "qty": 3
                         }
                     ]
                 },
                 {
                     "description": "+10% effect chance",
                     "resources": [
-                        {
-                            "item": "path-power-loop",
-                            "qty": 4
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 28000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "path-power-loop",
+                            "qty": 4
                         }
                     ]
                 },
@@ -361,16 +361,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "path-power-loop",
+                            "qty": 5
                         }
                     ]
                 },
@@ -378,16 +378,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "path-power-loop",
+                            "qty": 6
                         }
                     ]
                 }
@@ -471,6 +471,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "spd",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/tywin.json
+++ b/src/hero/tywin.json
@@ -100,12 +100,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -113,12 +113,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -126,16 +126,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "path-power-loop",
+                            "qty": 2
                         }
                     ]
                 },
@@ -143,16 +143,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 36000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 36000
+                            "item": "path-power-loop",
+                            "qty": 4
                         }
                     ]
                 },
@@ -160,16 +160,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "path-power-loop",
+                            "qty": 5
                         }
                     ]
                 },
@@ -177,16 +177,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "nightmare-mask",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "nightmare-mask",
+                            "qty": 2
                         }
                     ]
                 }
@@ -236,16 +236,16 @@
                     "description": "Acquire +1 soul",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "path-power-loop",
+                            "qty": 5
                         }
                     ]
                 },
@@ -253,16 +253,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "nightmare-mask",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "nightmare-mask",
+                            "qty": 2
                         }
                     ]
                 }
@@ -305,12 +305,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -318,12 +318,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -331,12 +331,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -344,16 +344,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "path-power-loop",
+                            "qty": 3
                         }
                     ]
                 },
@@ -361,16 +361,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "path-power-loop",
+                            "qty": 4
                         }
                     ]
                 },
@@ -378,16 +378,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 55000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 55000
+                            "item": "path-power-loop",
+                            "qty": 7
                         }
                     ]
                 },
@@ -395,16 +395,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "nightmare-mask",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 110000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 110000
+                            "item": "nightmare-mask",
+                            "qty": 3
                         }
                     ]
                 }
@@ -492,6 +492,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/vildred.json
+++ b/src/hero/vildred.json
@@ -108,25 +108,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -134,16 +134,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 },
@@ -151,16 +151,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "twisted-fang",
+                            "qty": 7
                         }
                     ]
                 },
@@ -168,16 +168,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -228,25 +228,25 @@
                     "description": "+5% damage dealt by additional skill",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt by additional skill",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -254,16 +254,16 @@
                     "description": "+5% damage dealt by additional skill",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 },
@@ -271,16 +271,16 @@
                     "description": "+5% damage dealt by additional skill",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "twisted-fang",
+                            "qty": 7
                         }
                     ]
                 },
@@ -288,16 +288,16 @@
                     "description": "+10% damage dealt by additional skill",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -340,12 +340,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -353,12 +353,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -366,16 +366,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 },
@@ -383,16 +383,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "twisted-fang",
+                            "qty": 7
                         }
                     ]
                 },
@@ -400,16 +400,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -493,6 +493,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "spd",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/violet.json
+++ b/src/hero/violet.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -130,29 +130,29 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -160,33 +160,33 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "sharp-spearhead",
+                            "qty": 4
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 7
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 55000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 7
                         }
                     ]
                 },
@@ -194,16 +194,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 110000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 110000
+                            "item": "black-curse-powder",
+                            "qty": 3
                         }
                     ]
                 }
@@ -246,16 +246,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 8
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "sharp-spearhead",
+                            "qty": 8
                         }
                     ]
                 }
@@ -296,12 +296,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -309,12 +309,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -322,29 +322,29 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -352,33 +352,33 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 40000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 40000
+                            "item": "sharp-spearhead",
+                            "qty": 4
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "sharp-spearhead",
-                            "qty": 7
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 55000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "sharp-spearhead",
+                            "qty": 7
                         }
                     ]
                 },
@@ -386,16 +386,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 110000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 110000
+                            "item": "black-curse-powder",
+                            "qty": 3
                         }
                     ]
                 }
@@ -469,6 +469,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/wanda.json
+++ b/src/hero/wanda.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+2% Combat Readiness",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+3% Combat Readiness",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "ring-of-glory",
+                            "qty": 1
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "ring-of-glory",
+                            "qty": 2
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "ring-of-glory",
+                            "qty": 4
                         }
                     ]
                 },
@@ -181,16 +181,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "ring-of-glory",
+                            "qty": 6
                         }
                     ]
                 }
@@ -233,16 +233,16 @@
                     "description": "+5% trigger chance",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 14000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 14000
+                            "item": "ring-of-glory",
+                            "qty": 2
                         }
                     ]
                 },
@@ -250,16 +250,16 @@
                     "description": "+5% trigger chance",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 23000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 23000
+                            "item": "ring-of-glory",
+                            "qty": 3
                         }
                     ]
                 },
@@ -267,16 +267,16 @@
                     "description": "+10% trigger chance",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "ring-of-glory",
+                            "qty": 5
                         }
                     ]
                 }
@@ -319,12 +319,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -332,29 +332,29 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+10% effect chance",
                     "resources": [
-                        {
-                            "item": "ring-of-glory",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 13000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
+                        },
+                        {
+                            "item": "ring-of-glory",
+                            "qty": 1
                         }
                     ]
                 },
@@ -362,16 +362,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 18000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 18000
+                            "item": "ring-of-glory",
+                            "qty": 2
                         }
                     ]
                 },
@@ -379,16 +379,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 32000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 32000
+                            "item": "ring-of-glory",
+                            "qty": 4
                         }
                     ]
                 },
@@ -396,16 +396,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "ring-of-glory",
-                            "qty": 6
+                            "item": "gold",
+                            "qty": 50000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 50000
+                            "item": "ring-of-glory",
+                            "qty": 6
                         }
                     ]
                 }
@@ -481,6 +481,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/wanderer-silk.json
+++ b/src/hero/wanderer-silk.json
@@ -92,12 +92,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -105,29 +105,29 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+5% effect chance",
                     "resources": [
-                        {
-                            "item": "slime-jelly",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 17000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "slime-jelly",
+                            "qty": 1
                         }
                     ]
                 },
@@ -135,16 +135,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "slime-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -152,16 +152,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "dragons-wrath",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "dragons-wrath",
+                            "qty": 2
                         }
                     ]
                 }
@@ -214,12 +214,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -227,46 +227,29 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "slime-jelly",
-                            "qty": 1
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 17000
-                        }
-                    ]
-                },
-                {
-                    "description": "+10% damage dealt",
-                    "resources": [
-                        {
-                            "item": "slime-jelly",
-                            "qty": 3
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "slime-jelly",
+                            "qty": 1
                         }
                     ]
                 },
@@ -274,16 +257,33 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "dragons-wrath",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "slime-jelly",
+                            "qty": 3
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "dragons-wrath",
+                            "qty": 2
                         }
                     ]
                 }
@@ -334,12 +334,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -347,12 +347,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -360,33 +360,33 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "slime-jelly",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "slime-jelly",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+15% damage dealt",
                     "resources": [
-                        {
-                            "item": "slime-jelly",
-                            "qty": 3
-                        },
-                        {
-                            "item": "molagora",
-                            "qty": 3
-                        },
                         {
                             "item": "gold",
                             "qty": 27000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "slime-jelly",
+                            "qty": 3
                         }
                     ]
                 },
@@ -394,16 +394,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "dragons-wrath",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "dragons-wrath",
+                            "qty": 2
                         }
                     ]
                 }
@@ -490,6 +490,7 @@
         "east": true,
         "west": false
     },
+    "memoryImprintAttribute": "chc",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/watcher-schuri.json
+++ b/src/hero/watcher-schuri.json
@@ -96,12 +96,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -109,12 +109,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -122,16 +122,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
@@ -139,16 +139,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -156,16 +156,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -207,12 +207,12 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -220,12 +220,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -233,16 +233,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
@@ -250,16 +250,16 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -267,16 +267,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -318,12 +318,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -331,12 +331,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -344,16 +344,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 17000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 17000
+                            "item": "sharp-spearhead",
+                            "qty": 1
                         }
                     ]
                 },
@@ -361,16 +361,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "sharp-spearhead",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 27000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 27000
+                            "item": "sharp-spearhead",
+                            "qty": 3
                         }
                     ]
                 },
@@ -378,16 +378,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "black-curse-powder",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "black-curse-powder",
+                            "qty": 2
                         }
                     ]
                 }
@@ -461,6 +461,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "spd",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/yufine.json
+++ b/src/hero/yufine.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,12 +117,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -130,16 +130,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "shiny-enchantment",
+                            "qty": 2
                         }
                     ]
                 },
@@ -147,16 +147,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 36000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 36000
+                            "item": "shiny-enchantment",
+                            "qty": 4
                         }
                     ]
                 },
@@ -164,16 +164,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "shiny-enchantment",
+                            "qty": 5
                         }
                     ]
                 },
@@ -181,16 +181,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "horn-of-desire",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "horn-of-desire",
+                            "qty": 2
                         }
                     ]
                 }
@@ -233,16 +233,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 19000
                         },
                         {
                             "item": "molagora",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 19000
+                            "item": "shiny-enchantment",
+                            "qty": 3
                         }
                     ]
                 },
@@ -250,16 +250,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 37000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 37000
+                            "item": "shiny-enchantment",
+                            "qty": 5
                         }
                     ]
                 },
@@ -267,16 +267,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "horn-of-desire",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 130000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 130000
+                            "item": "horn-of-desire",
+                            "qty": 3
                         }
                     ]
                 }
@@ -322,12 +322,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -335,12 +335,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -348,16 +348,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "shiny-enchantment",
+                            "qty": 2
                         }
                     ]
                 },
@@ -365,33 +365,33 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 36000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 36000
+                            "item": "shiny-enchantment",
+                            "qty": 4
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "shiny-enchantment",
-                            "qty": 5
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 45000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "shiny-enchantment",
+                            "qty": 5
                         }
                     ]
                 },
@@ -399,16 +399,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "horn-of-desire",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "horn-of-desire",
+                            "qty": 2
                         }
                     ]
                 }
@@ -484,6 +484,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "atk",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/yuna.json
+++ b/src/hero/yuna.json
@@ -116,25 +116,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -142,16 +142,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "twisted-fang",
+                            "qty": 2
                         }
                     ]
                 },
@@ -159,16 +159,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 4
+                            "item": "gold",
+                            "qty": 36000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 36000
+                            "item": "twisted-fang",
+                            "qty": 4
                         }
                     ]
                 },
@@ -176,16 +176,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 45000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 45000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 },
@@ -193,16 +193,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -243,16 +243,16 @@
                     "description": "+2 Soul acquired",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "twisted-fang",
+                            "qty": 5
                         }
                     ]
                 },
@@ -260,16 +260,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "blazing-soul",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "blazing-soul",
+                            "qty": 2
                         }
                     ]
                 }
@@ -313,38 +313,25 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+5% damage dealt",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
-                        }
-                    ]
-                },
-                {
-                    "description": "+5% damage dealt",
-                    "resources": [
+                        },
                         {
                             "item": "molagora",
                             "qty": 2
-                        },
-                        {
-                            "item": "gold",
-                            "qty": 8000
                         }
                     ]
                 },
@@ -352,67 +339,80 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "twisted-fang",
-                            "qty": 3
+                            "item": "gold",
+                            "qty": 8000
                         },
                         {
                             "item": "molagora",
-                            "qty": 3
-                        },
+                            "qty": 2
+                        }
+                    ]
+                },
+                {
+                    "description": "+5% damage dealt",
+                    "resources": [
                         {
                             "item": "gold",
                             "qty": 27000
-                        }
-                    ]
-                },
-                {
-                    "description": "+10% damage dealt",
-                    "resources": [
-                        {
-                            "item": "twisted-fang",
-                            "qty": 4
                         },
                         {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
-                        {
-                            "item": "gold",
-                            "qty": 40000
-                        }
-                    ]
-                },
-                {
-                    "description": "+10% damage dealt",
-                    "resources": [
-                        {
-                            "item": "twisted-fang",
-                            "qty": 7
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
-                        {
-                            "item": "gold",
-                            "qty": 55000
-                        }
-                    ]
-                },
-                {
-                    "description": "+10% damage dealt",
-                    "resources": [
-                        {
-                            "item": "blazing-soul",
+                            "item": "molagora",
                             "qty": 3
                         },
                         {
+                            "item": "twisted-fang",
+                            "qty": 3
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 40000
+                        },
+                        {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
+                            "item": "twisted-fang",
+                            "qty": 4
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 55000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "twisted-fang",
+                            "qty": 7
+                        }
+                    ]
+                },
+                {
+                    "description": "+10% damage dealt",
+                    "resources": [
+                        {
                             "item": "gold",
                             "qty": 110000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "blazing-soul",
+                            "qty": 3
                         }
                     ]
                 }
@@ -486,6 +486,7 @@
         "east": false,
         "west": true
     },
+    "memoryImprintAttribute": "hp",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/zeno.json
+++ b/src/hero/zeno.json
@@ -96,12 +96,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -109,12 +109,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -122,16 +122,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "shiny-enchantment",
+                            "qty": 5
                         }
                     ]
                 },
@@ -139,16 +139,16 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "shiny-enchantment",
+                            "qty": 7
                         }
                     ]
                 },
@@ -156,16 +156,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "horn-of-desire",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "horn-of-desire",
+                            "qty": 2
                         }
                     ]
                 }
@@ -218,25 +218,25 @@
                     "description": "+0.5% effect",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
                 {
                     "description": "+0.5% effect",
                     "resources": [
-                        {
-                            "item": "molagora",
-                            "qty": 2
-                        },
                         {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -244,16 +244,16 @@
                     "description": "+0.5% effect",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "shiny-enchantment",
+                            "qty": 5
                         }
                     ]
                 },
@@ -261,16 +261,16 @@
                     "description": "+0.5% effect",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "shiny-enchantment",
+                            "qty": 7
                         }
                     ]
                 },
@@ -278,16 +278,16 @@
                     "description": "+1% effect",
                     "resources": [
                         {
-                            "item": "horn-of-desire",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "horn-of-desire",
+                            "qty": 2
                         }
                     ]
                 }
@@ -328,12 +328,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -341,12 +341,12 @@
                     "description": "+5% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -354,16 +354,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 5
+                            "item": "gold",
+                            "qty": 33000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 33000
+                            "item": "shiny-enchantment",
+                            "qty": 5
                         }
                     ]
                 },
@@ -371,16 +371,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "shiny-enchantment",
-                            "qty": 7
+                            "item": "gold",
+                            "qty": 47000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 47000
+                            "item": "shiny-enchantment",
+                            "qty": 7
                         }
                     ]
                 },
@@ -388,16 +388,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "horn-of-desire",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 100000
                         },
                         {
                             "item": "molagorago",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 100000
+                            "item": "horn-of-desire",
+                            "qty": 2
                         }
                     ]
                 }
@@ -484,6 +484,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "eff",
     "memoryImprint": [
         {
             "rank": "d",

--- a/src/hero/zerato.json
+++ b/src/hero/zerato.json
@@ -104,12 +104,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -117,16 +117,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "path-power-loop",
+                            "qty": 1
                         }
                     ]
                 },
@@ -134,16 +134,16 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 21000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 21000
+                            "item": "path-power-loop",
+                            "qty": 1
                         }
                     ]
                 },
@@ -151,16 +151,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "nightmare-mask",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "nightmare-mask",
+                            "qty": 2
                         }
                     ]
                 }
@@ -203,12 +203,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -216,16 +216,16 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "path-power-loop",
+                            "qty": 1
                         }
                     ]
                 },
@@ -233,16 +233,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 21000
                         },
                         {
                             "item": "molagora",
                             "qty": 4
                         },
                         {
-                            "item": "gold",
-                            "qty": 21000
+                            "item": "path-power-loop",
+                            "qty": 1
                         }
                     ]
                 },
@@ -250,16 +250,16 @@
                     "description": "+15% damage dealt",
                     "resources": [
                         {
-                            "item": "nightmare-mask",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "nightmare-mask",
+                            "qty": 2
                         }
                     ]
                 }
@@ -300,12 +300,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -313,12 +313,12 @@
                     "description": "+5% damage dealt",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 1
-                        },
-                        {
                             "item": "gold",
                             "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
                         }
                     ]
                 },
@@ -326,12 +326,12 @@
                     "description": "+10% effect chance",
                     "resources": [
                         {
-                            "item": "molagora",
-                            "qty": 2
-                        },
-                        {
                             "item": "gold",
                             "qty": 8000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 2
                         }
                     ]
                 },
@@ -339,16 +339,16 @@
                     "description": "-1 turn cooldown",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 1
+                            "item": "gold",
+                            "qty": 13000
                         },
                         {
                             "item": "molagora",
                             "qty": 2
                         },
                         {
-                            "item": "gold",
-                            "qty": 13000
+                            "item": "path-power-loop",
+                            "qty": 1
                         }
                     ]
                 },
@@ -356,33 +356,33 @@
                     "description": "+15% effect chance",
                     "resources": [
                         {
-                            "item": "path-power-loop",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 22000
                         },
                         {
                             "item": "molagora",
                             "qty": 3
                         },
                         {
-                            "item": "gold",
-                            "qty": 22000
+                            "item": "path-power-loop",
+                            "qty": 2
                         }
                     ]
                 },
                 {
                     "description": "+10% damage dealt",
                     "resources": [
-                        {
-                            "item": "path-power-loop",
-                            "qty": 5
-                        },
-                        {
-                            "item": "molagorago",
-                            "qty": 1
-                        },
                         {
                             "item": "gold",
                             "qty": 45000
+                        },
+                        {
+                            "item": "molagorago",
+                            "qty": 1
+                        },
+                        {
+                            "item": "path-power-loop",
+                            "qty": 5
                         }
                     ]
                 },
@@ -390,16 +390,16 @@
                     "description": "+10% damage dealt",
                     "resources": [
                         {
-                            "item": "nightmare-mask",
-                            "qty": 2
+                            "item": "gold",
+                            "qty": 80000
                         },
                         {
                             "item": "molagorago",
                             "qty": 1
                         },
                         {
-                            "item": "gold",
-                            "qty": 80000
+                            "item": "nightmare-mask",
+                            "qty": 2
                         }
                     ]
                 }
@@ -475,6 +475,7 @@
         "east": true,
         "west": true
     },
+    "memoryImprintAttribute": "def",
     "memoryImprint": [
         {
             "rank": "d",


### PR DESCRIPTION
Fixed skill enhancement item order.
gold -> molagora -> catalyst
Added memoryImprintAttribute field

Khawazu had a mistake, +1 had epic catalyst instead of rare.