### PR TITLE
Cleaned up modifiers and fixes

### DIFF
--- a/src/hero/achates.json
+++ b/src/hero/achates.json
@@ -200,9 +200,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 0.95 * 1.871",
+                "value": "((1 * hero_atk)) * 0.95 * 1.871",
                 "simplified": "((1.7774 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 0.95 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 0.95 * 1.871",
                 "simplifiedSoulburn": "((1.7774 * hero_atk))"
             }
         },

--- a/src/hero/adlay.json
+++ b/src/hero/adlay.json
@@ -196,9 +196,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -418,9 +418,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.25 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1.25 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((2.3388 * hero_atk))"
             }
         }

--- a/src/hero/aither.json
+++ b/src/hero/aither.json
@@ -195,9 +195,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.05 * 1.871",
+                "value": "((1 * hero_atk)) * 1.05 * 1.871",
                 "simplified": "((1.9646 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.05 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1.05 * 1.871",
                 "simplifiedSoulburn": "((1.9646 * hero_atk))"
             }
         },

--- a/src/hero/alexa.json
+++ b/src/hero/alexa.json
@@ -172,9 +172,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -302,9 +302,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },

--- a/src/hero/alexa.json
+++ b/src/hero/alexa.json
@@ -428,18 +428,18 @@
                     "soulburn": 1.5
                 },
                 {
-                    "name": "skill_dmg_rate",
+                    "name": "target_debuff_rate",
                     "description": "Increased damage per target debuff.",
                     "value": 0.15,
                     "soulburn": 0.15
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((1.5 * hero_atk)) * (1 + ((0.15 * hero_special_count))) * 0.9 * 1.871",
-                "simplified": "((2.5259 * hero_atk)) * (1 + ((0.15 * hero_special_count)))",
-                "soulburn": "((1.5 * hero_atk)) * (1 + ((0.15 * hero_special_count))) * 0.9 * 1.871",
-                "simplifiedSoulburn": "((2.5259 * hero_atk)) * (1 + ((0.15 * hero_special_count)))"
+                "description": "((atk_rate * hero_atk)) * (1 + ((target_debuff_rate * target_num_debuffs))) * pow! * constant",
+                "value": "((1.5 * hero_atk)) * (1 + ((0.15 * target_num_debuffs))) * 0.9 * 1.871",
+                "simplified": "((2.5259 * hero_atk)) * (1 + ((0.15 * target_num_debuffs)))",
+                "soulburn": "((1.5 * hero_atk)) * (1 + ((0.15 * target_num_debuffs))) * 0.9 * 1.871",
+                "simplifiedSoulburn": "((2.5259 * hero_atk)) * (1 + ((0.15 * target_num_debuffs)))"
             }
         }
     ],

--- a/src/hero/alexa.json
+++ b/src/hero/alexa.json
@@ -435,11 +435,11 @@
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((target_debuff_rate * target_num_debuffs))) * pow! * constant",
-                "value": "((1.5 * hero_atk)) * (1 + ((0.15 * target_num_debuffs))) * 0.9 * 1.871",
-                "simplified": "((2.5259 * hero_atk)) * (1 + ((0.15 * target_num_debuffs)))",
-                "soulburn": "((1.5 * hero_atk)) * (1 + ((0.15 * target_num_debuffs))) * 0.9 * 1.871",
-                "simplifiedSoulburn": "((2.5259 * hero_atk)) * (1 + ((0.15 * target_num_debuffs)))"
+                "description": "((atk_rate * hero_atk)) * (1 + ((target_debuff_rate * target_debuffs))) * pow! * constant",
+                "value": "((1.5 * hero_atk)) * (1 + ((0.15 * target_debuffs))) * 0.9 * 1.871",
+                "simplified": "((2.5259 * hero_atk)) * (1 + ((0.15 * target_debuffs)))",
+                "soulburn": "((1.5 * hero_atk)) * (1 + ((0.15 * target_debuffs))) * 0.9 * 1.871",
+                "simplifiedSoulburn": "((2.5259 * hero_atk)) * (1 + ((0.15 * target_debuffs)))"
             }
         }
     ],

--- a/src/hero/angelic-montmorancy.json
+++ b/src/hero/angelic-montmorancy.json
@@ -192,9 +192,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },

--- a/src/hero/angelica.json
+++ b/src/hero/angelica.json
@@ -196,9 +196,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },

--- a/src/hero/apocalypse-ravi.json
+++ b/src/hero/apocalypse-ravi.json
@@ -204,7 +204,7 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (hp_rate * hero_hp)) * pow! * constant",
-                "value": "((1.0 * hero_atk) + (0.12 * hero_hp)) * 0.95 * 1.871",
+                "value": "((1 * hero_atk) + (0.12 * hero_hp)) * 0.95 * 1.871",
                 "simplified": "((1.7774 * hero_atk) + (0.2133 * hero_hp))",
                 "soulburn": "((1.8 * hero_atk) + (0.2 * hero_hp)) * 0.95 * 1.871",
                 "simplifiedSoulburn": "((3.1994 * hero_atk) + (0.3555 * hero_hp))"

--- a/src/hero/aramintha.json
+++ b/src/hero/aramintha.json
@@ -199,9 +199,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.05 * 1.871",
+                "value": "((1 * hero_atk)) * 1.05 * 1.871",
                 "simplified": "((1.9646 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.05 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1.05 * 1.871",
                 "simplifiedSoulburn": "((1.9646 * hero_atk))"
             }
         },
@@ -302,10 +302,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.8 * hero_atk)) * 1.0 * 1.871",
-                "simplified": "((1.497 * hero_atk))",
-                "soulburn": "((0.8 * hero_atk)) * 1.0 * 1.871",
-                "simplifiedSoulburn": "((1.497 * hero_atk))"
+                "value": "((0.8 * hero_atk)) * 1 * 1.871",
+                "simplified": "((1.4968 * hero_atk))",
+                "soulburn": "((0.8 * hero_atk)) * 1 * 1.871",
+                "simplifiedSoulburn": "((1.4968 * hero_atk))"
             }
         },
         {
@@ -446,9 +446,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.85 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.85 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.5903 * hero_atk))",
-                "soulburn": "((0.85 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((0.85 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.5903 * hero_atk))"
             }
         }

--- a/src/hero/arbiter-vildred.json
+++ b/src/hero/arbiter-vildred.json
@@ -227,9 +227,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.975 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.975 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.8242 * hero_atk))",
-                "soulburn": "((0.975 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((0.975 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.8242 * hero_atk))"
             }
         },
@@ -448,10 +448,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "(([1.04, 1.23] * hero_atk)) * 0.85 * 1.871",
-                "simplified": "(([1.654, 1.9561] * hero_atk))",
-                "soulburn": "(([1.29, 1.55] * hero_atk)) * 0.85 * 1.871",
-                "simplifiedSoulburn": "(([2.0516, 2.465] * hero_atk))"
+                "value": "((atk_rate[1.04, 1.23] * hero_atk)) * 0.85 * 1.871",
+                "simplified": "((atk_rate[1.654, 1.9561] * hero_atk))",
+                "soulburn": "((atk_rate[1.29, 1.55] * hero_atk)) * 0.85 * 1.871",
+                "simplifiedSoulburn": "((atk_rate[2.0516, 2.465] * hero_atk))"
             }
         }
     ],

--- a/src/hero/assassin-cartuja.json
+++ b/src/hero/assassin-cartuja.json
@@ -188,9 +188,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },

--- a/src/hero/assassin-cidd.json
+++ b/src/hero/assassin-cidd.json
@@ -218,9 +218,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((spd_rate * hero_spd))) * pow! * constant",
-                "value": "((0.9 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1.0 * 1.871",
+                "value": "((0.9 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1 * 1.871",
                 "simplified": "((1.6839 * hero_atk)) * (1 + ((0.00075 * hero_spd)))",
-                "soulburn": "((0.9 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1.0 * 1.871",
+                "soulburn": "((0.9 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.6839 * hero_atk)) * (1 + ((0.00075 * hero_spd)))"
             }
         },
@@ -444,11 +444,11 @@
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((spd_rate * hero_spd) * (target_spd_rate * target_spd))) * pow! * constant",
-                "value": "((1.5 * hero_atk)) * (1 + ((0.001 * hero_spd) * (0.003 * target_spd))) * 0.95 * 1.871",
-                "simplified": "((2.6662 * hero_atk)) * (1 + ((0.001 * hero_spd) * (0.003 * target_spd)))",
-                "soulburn": "((2.0 * hero_atk)) * (1 + ((0.001 * hero_spd) * (0.003 * target_spd))) * 0.95 * 1.871",
-                "simplifiedSoulburn": "((3.5549 * hero_atk)) * (1 + ((0.001 * hero_spd) * (0.003 * target_spd)))"
+                "description": "((atk_rate * hero_atk)) * (1 + ((spd_rate * hero_spd) + (target_spd_rate * target_spd))) * pow! * constant",
+                "value": "((1.5 * hero_atk)) * (1 + ((0.001 * hero_spd) + (0.003 * target_spd))) * 0.95 * 1.871",
+                "simplified": "((2.6662 * hero_atk)) * (1 + ((0.001 * hero_spd) + (0.003 * target_spd)))",
+                "soulburn": "((2 * hero_atk)) * (1 + ((0.001 * hero_spd) + (0.003 * target_spd))) * 0.95 * 1.871",
+                "simplifiedSoulburn": "((3.5549 * hero_atk)) * (1 + ((0.001 * hero_spd) + (0.003 * target_spd)))"
             }
         }
     ],

--- a/src/hero/assassin-coli.json
+++ b/src/hero/assassin-coli.json
@@ -195,10 +195,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((spd_rate * hero_spd))) * pow! * constant",
-                "value": "(([0.9, 1.2] * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1.0 * 1.871",
-                "simplified": "(([1.684, 2.245] * hero_atk)) * (1 + ((0.00075 * hero_spd)))",
-                "soulburn": "(([0.9, 1.2] * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1.0 * 1.871",
-                "simplifiedSoulburn": "(([1.684, 2.245] * hero_atk)) * (1 + ((0.00075 * hero_spd)))"
+                "value": "((atk_rate[0.9, 1.2] * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1 * 1.871",
+                "simplified": "((atk_rate[1.6839, 2.2452] * hero_atk)) * (1 + ((0.00075 * hero_spd)))",
+                "soulburn": "((atk_rate[0.9, 1.2] * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1 * 1.871",
+                "simplifiedSoulburn": "((atk_rate[1.6839, 2.2452] * hero_atk)) * (1 + ((0.00075 * hero_spd)))"
             }
         },
         {
@@ -447,7 +447,7 @@
                 "description": "((atk_rate * hero_atk)) * (1 + ((spd_rate * hero_spd))) * pow! * constant",
                 "value": "((1.5 * hero_atk)) * (1 + ((0.001125 * hero_spd))) * 0.8 * 1.871",
                 "simplified": "((2.2452 * hero_atk)) * (1 + ((0.001125 * hero_spd)))",
-                "soulburn": "((3.0 * hero_atk)) * (1 + ((0.001125 * hero_spd))) * 0.8 * 1.871",
+                "soulburn": "((3 * hero_atk)) * (1 + ((0.001125 * hero_spd))) * 0.8 * 1.871",
                 "simplifiedSoulburn": "((4.4904 * hero_atk)) * (1 + ((0.001125 * hero_spd)))"
             }
         }

--- a/src/hero/auxiliary-lots.json
+++ b/src/hero/auxiliary-lots.json
@@ -209,9 +209,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 0.8 * 1.871",
+                "value": "((1 * hero_atk)) * 0.8 * 1.871",
                 "simplified": "((1.4968 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 0.8 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 0.8 * 1.871",
                 "simplifiedSoulburn": "((1.4968 * hero_atk))"
             }
         },
@@ -426,9 +426,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.8 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.8 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.4968 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         }

--- a/src/hero/azalea.json
+++ b/src/hero/azalea.json
@@ -194,9 +194,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.05 * 1.871",
+                "value": "((1 * hero_atk)) * 1.05 * 1.871",
                 "simplified": "((1.9646 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.05 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1.05 * 1.871",
                 "simplifiedSoulburn": "((1.9646 * hero_atk))"
             }
         },
@@ -421,9 +421,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.7 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.7 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.3097 * hero_atk))",
-                "soulburn": "((0.7 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((0.7 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.3097 * hero_atk))"
             }
         }

--- a/src/hero/baal-sezan.json
+++ b/src/hero/baal-sezan.json
@@ -170,9 +170,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -436,9 +436,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.8 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.8 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.4968 * hero_atk))",
-                "soulburn": "((0.8 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((0.8 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.4968 * hero_atk))"
             }
         }

--- a/src/hero/baal-sezan.json
+++ b/src/hero/baal-sezan.json
@@ -303,11 +303,11 @@
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((target_debuff_rate * target_num_debuffs))) * pow! * constant",
-                "value": "((1.1 * hero_atk)) * (1 + ((0.15 * target_num_debuffs))) * 0.9 * 1.871",
-                "simplified": "((1.8523 * hero_atk)) * (1 + ((0.15 * target_num_debuffs)))",
-                "soulburn": "((1.35 * hero_atk)) * (1 + ((0.15 * target_num_debuffs))) * 0.9 * 1.871",
-                "simplifiedSoulburn": "((2.2733 * hero_atk)) * (1 + ((0.15 * target_num_debuffs)))"
+                "description": "((atk_rate * hero_atk)) * (1 + ((target_debuff_rate * target_debuffs))) * pow! * constant",
+                "value": "((1.1 * hero_atk)) * (1 + ((0.15 * target_debuffs))) * 0.9 * 1.871",
+                "simplified": "((1.8523 * hero_atk)) * (1 + ((0.15 * target_debuffs)))",
+                "soulburn": "((1.35 * hero_atk)) * (1 + ((0.15 * target_debuffs))) * 0.9 * 1.871",
+                "simplifiedSoulburn": "((2.2733 * hero_atk)) * (1 + ((0.15 * target_debuffs)))"
             }
         },
         {

--- a/src/hero/baal-sezan.json
+++ b/src/hero/baal-sezan.json
@@ -296,18 +296,18 @@
                     "soulburn": 1.35
                 },
                 {
-                    "name": "skill_dmg_rate",
+                    "name": "target_debuff_rate",
                     "description": "Increased damage per debuff on target.",
                     "value": 0.15,
                     "soulburn": 0.15
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((1.1 * hero_atk)) * (1 + ((0.15 * hero_special_count))) * 0.9 * 1.871",
-                "simplified": "((1.8523 * hero_atk)) * (1 + ((0.15 * hero_special_count)))",
-                "soulburn": "((1.35 * hero_atk)) * (1 + ((0.15 * hero_special_count))) * 0.9 * 1.871",
-                "simplifiedSoulburn": "((2.2733 * hero_atk)) * (1 + ((0.15 * hero_special_count)))"
+                "description": "((atk_rate * hero_atk)) * (1 + ((target_debuff_rate * target_num_debuffs))) * pow! * constant",
+                "value": "((1.1 * hero_atk)) * (1 + ((0.15 * target_num_debuffs))) * 0.9 * 1.871",
+                "simplified": "((1.8523 * hero_atk)) * (1 + ((0.15 * target_num_debuffs)))",
+                "soulburn": "((1.35 * hero_atk)) * (1 + ((0.15 * target_num_debuffs))) * 0.9 * 1.871",
+                "simplifiedSoulburn": "((2.2733 * hero_atk)) * (1 + ((0.15 * target_num_debuffs)))"
             }
         },
         {

--- a/src/hero/baiken.json
+++ b/src/hero/baiken.json
@@ -196,9 +196,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -309,9 +309,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.2 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1.2 * hero_atk)) * 1 * 1.871",
                 "simplified": "((2.2452 * hero_atk))",
-                "soulburn": "((1.2 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1.2 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((2.2452 * hero_atk))"
             }
         },
@@ -420,9 +420,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.6 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1.6 * hero_atk)) * 1 * 1.871",
                 "simplified": "((2.9936 * hero_atk))",
-                "soulburn": "((1.85 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1.85 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((3.4614 * hero_atk))"
             }
         }

--- a/src/hero/basar.json
+++ b/src/hero/basar.json
@@ -190,9 +190,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -304,9 +304,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.9 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.9 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.6839 * hero_atk))",
-                "soulburn": "((0.9 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((0.9 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.6839 * hero_atk))"
             }
         },

--- a/src/hero/bask.json
+++ b/src/hero/bask.json
@@ -364,9 +364,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (hp_rate * hero_hp)) * pow! * constant",
-                "value": "((0.8 * hero_atk) + (0.12 * hero_hp)) * 1.0 * 1.871",
+                "value": "((0.8 * hero_atk) + (0.12 * hero_hp)) * 1 * 1.871",
                 "simplified": "((1.4968 * hero_atk) + (0.2245 * hero_hp))",
-                "soulburn": "((0.8 * hero_atk) + (0.12 * hero_hp)) * 1.0 * 1.871",
+                "soulburn": "((0.8 * hero_atk) + (0.12 * hero_hp)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.4968 * hero_atk) + (0.2245 * hero_hp))"
             }
         },

--- a/src/hero/bellona.json
+++ b/src/hero/bellona.json
@@ -312,18 +312,28 @@
                     "soulburn": 0.8
                 },
                 {
-                    "name": "skill_dmg_rate",
+                    "name": "targets_rate",
                     "description": "Increased damage per target beyond 1.",
-                    "value": 0.1,
-                    "soulburn": 0.1
+                    "value": [
+                        0,
+                        0.1,
+                        0.2,
+                        0.3
+                    ],
+                    "soulburn": [
+                        0,
+                        0.1,
+                        0.2,
+                        0.3
+                    ]
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((0.8 * hero_atk)) * (1 + ((0.1 * hero_special_count))) * 0.95 * 1.871",
-                "simplified": "((1.422 * hero_atk)) * (1 + ((0.1 * hero_special_count)))",
-                "soulburn": "((0.8 * hero_atk)) * (1 + ((0.1 * hero_special_count))) * 0.95 * 1.871",
-                "simplifiedSoulburn": "((1.422 * hero_atk)) * (1 + ((0.1 * hero_special_count)))"
+                "description": "((atk_rate * hero_atk)) * (1 + (targets_rate)) * pow! * constant",
+                "value": "((0.8 * hero_atk)) * (1 + ((targets_rate[0, 0.1, 0.2, 0.3]))) * 0.95 * 1.871",
+                "simplified": "((1.422 * hero_atk)) * (1 + ((targets_rate[0, 0.1, 0.2, 0.3])))",
+                "soulburn": "((0.8 * hero_atk)) * (1 + ((targets_rate[0, 0.1, 0.2, 0.3]))) * 0.95 * 1.871",
+                "simplifiedSoulburn": "((1.422 * hero_atk)) * (1 + ((targets_rate[0, 0.1, 0.2, 0.3])))"
             }
         },
         {

--- a/src/hero/bellona.json
+++ b/src/hero/bellona.json
@@ -203,9 +203,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (hp_rate * hero_hp)) * pow! * constant",
-                "value": "((1.0 * hero_atk) + (0.04 * hero_hp)) * 0.95 * 1.871",
+                "value": "((1 * hero_atk) + (0.04 * hero_hp)) * 0.95 * 1.871",
                 "simplified": "((1.7774 * hero_atk) + (0.0711 * hero_hp))",
-                "soulburn": "((1.0 * hero_atk) + (0.04 * hero_hp)) * 0.95 * 1.871",
+                "soulburn": "((1 * hero_atk) + (0.04 * hero_hp)) * 0.95 * 1.871",
                 "simplifiedSoulburn": "((1.7774 * hero_atk) + (0.0711 * hero_hp))"
             }
         },
@@ -433,9 +433,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.95 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.95 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.7774 * hero_atk))",
-                "soulburn": "((1.2 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1.2 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((2.2452 * hero_atk))"
             }
         }

--- a/src/hero/blood-blade-karin.json
+++ b/src/hero/blood-blade-karin.json
@@ -205,10 +205,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "(([1.0, 1.167, 1.334, 1.501] * hero_atk)) * 1.0 * 1.871",
-                "simplified": "(([1.871, 2.1835, 2.4959, 2.8084] * hero_atk))",
-                "soulburn": "(([1.0, 1.167, 1.334, 1.501] * hero_atk)) * 1.0 * 1.871",
-                "simplifiedSoulburn": "(([1.871, 2.1835, 2.4959, 2.8084] * hero_atk))"
+                "value": "((atk_rate[1, 1.167, 1.334, 1.501] * hero_atk)) * 1 * 1.871",
+                "simplified": "((atk_rate[1.871, 2.1835, 2.4959, 2.8084] * hero_atk))",
+                "soulburn": "((atk_rate[1, 1.167, 1.334, 1.501] * hero_atk)) * 1 * 1.871",
+                "simplifiedSoulburn": "((atk_rate[1.871, 2.1835, 2.4959, 2.8084] * hero_atk))"
             }
         },
         {
@@ -438,10 +438,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "(([1.2, 1.367, 1.534, 1.701] * hero_atk)) * 0.95 * 1.871",
-                "simplified": "(([2.1329, 2.4298, 2.7266, 3.0234] * hero_atk))",
-                "soulburn": "(([1.45, 1.617, 1.784, 1.951] * hero_atk)) * 0.95 * 1.871",
-                "simplifiedSoulburn": "(([2.5773, 2.8741, 3.171, 3.4678] * hero_atk))"
+                "value": "((atk_rate[1.2, 1.367, 1.534, 1.701] * hero_atk)) * 0.95 * 1.871",
+                "simplified": "((atk_rate[2.1329, 2.4298, 2.7266, 3.0234] * hero_atk))",
+                "soulburn": "((atk_rate[1.45, 1.617, 1.784, 1.951] * hero_atk)) * 0.95 * 1.871",
+                "simplifiedSoulburn": "((atk_rate[2.5773, 2.8741, 3.171, 3.4678] * hero_atk))"
             }
         }
     ],

--- a/src/hero/butcher-corps-inquisitor.json
+++ b/src/hero/butcher-corps-inquisitor.json
@@ -203,9 +203,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },

--- a/src/hero/captain-rikoris.json
+++ b/src/hero/captain-rikoris.json
@@ -213,9 +213,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -426,9 +426,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.85 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.85 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.5903 * hero_atk))",
-                "soulburn": "((0.85 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((0.85 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.5903 * hero_atk))"
             }
         }

--- a/src/hero/carmainerose.json
+++ b/src/hero/carmainerose.json
@@ -190,9 +190,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },

--- a/src/hero/carrot.json
+++ b/src/hero/carrot.json
@@ -221,9 +221,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 0.95 * 1.871",
+                "value": "((1 * hero_atk)) * 0.95 * 1.871",
                 "simplified": "((1.7774 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 0.95 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 0.95 * 1.871",
                 "simplifiedSoulburn": "((1.7774 * hero_atk))"
             }
         },
@@ -436,9 +436,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         }

--- a/src/hero/cartuja.json
+++ b/src/hero/cartuja.json
@@ -222,9 +222,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (hp_rate * hero_hp)) * pow! * constant",
-                "value": "((0.5 * hero_atk) + (0.06 * hero_hp)) * 1.0 * 1.871",
+                "value": "((0.5 * hero_atk) + (0.06 * hero_hp)) * 1 * 1.871",
                 "simplified": "((0.9355 * hero_atk) + (0.1123 * hero_hp))",
-                "soulburn": "((0.5 * hero_atk) + (0.06 * hero_hp)) * 1.0 * 1.871",
+                "soulburn": "((0.5 * hero_atk) + (0.06 * hero_hp)) * 1 * 1.871",
                 "simplifiedSoulburn": "((0.9355 * hero_atk) + (0.1123 * hero_hp))"
             }
         },
@@ -458,10 +458,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (hp_rate * hero_hp)) * pow! * constant",
-                "value": "(([0.6, 1.0] * hero_atk) + ([0.05, 0.625] * hero_hp)) * 1.0 * 1.871",
-                "simplified": "(([1.1226, 1.871] * hero_atk) + ([0.0936, 1.1694] * hero_hp))",
-                "soulburn": "(([0.8, 1.2] * hero_atk) + ([0.08, 0.1] * hero_hp)) * 1.0 * 1.871",
-                "simplifiedSoulburn": "(([1.4968, 2.2452] * hero_atk) + ([0.1497, 0.1871] * hero_hp))"
+                "value": "((atk_rate[0.6, 1] * hero_atk) + (hp_rate[0.05, 0.625] * hero_hp)) * 1 * 1.871",
+                "simplified": "((atk_rate[1.1226, 1.871] * hero_atk) + (hp_rate[0.0936, 1.1694] * hero_hp))",
+                "soulburn": "((atk_rate[0.8, 1.2] * hero_atk) + (hp_rate[0.08, 0.1] * hero_hp)) * 1 * 1.871",
+                "simplifiedSoulburn": "((atk_rate[1.4968, 2.2452] * hero_atk) + (hp_rate[0.1497, 0.1871] * hero_hp))"
             }
         }
     ],

--- a/src/hero/cecilia.json
+++ b/src/hero/cecilia.json
@@ -208,9 +208,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (hp_rate * hero_hp)) * pow! * constant",
-                "value": "((0.7 * hero_atk) + (0.07 * hero_hp)) * 1.0 * 1.871",
+                "value": "((0.7 * hero_atk) + (0.07 * hero_hp)) * 1 * 1.871",
                 "simplified": "((1.3097 * hero_atk) + (0.131 * hero_hp))",
-                "soulburn": "((0.7 * hero_atk) + (0.07 * hero_hp)) * 1.0 * 1.871",
+                "soulburn": "((0.7 * hero_atk) + (0.07 * hero_hp)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.3097 * hero_atk) + (0.131 * hero_hp))"
             }
         },
@@ -325,9 +325,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (hp_rate * hero_hp)) * pow! * constant",
-                "value": "((0.4 * hero_atk) + (0.06 * hero_hp)) * 1.0 * 1.871",
+                "value": "((0.4 * hero_atk) + (0.06 * hero_hp)) * 1 * 1.871",
                 "simplified": "((0.7484 * hero_atk) + (0.1123 * hero_hp))",
-                "soulburn": "((0.4 * hero_atk) + (0.06 * hero_hp)) * 1.0 * 1.871",
+                "soulburn": "((0.4 * hero_atk) + (0.06 * hero_hp)) * 1 * 1.871",
                 "simplifiedSoulburn": "((0.7484 * hero_atk) + (0.1123 * hero_hp))"
             }
         },

--- a/src/hero/celeste.json
+++ b/src/hero/celeste.json
@@ -209,9 +209,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },

--- a/src/hero/celestial-mercedes.json
+++ b/src/hero/celestial-mercedes.json
@@ -200,9 +200,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },

--- a/src/hero/cermia.json
+++ b/src/hero/cermia.json
@@ -226,9 +226,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.2 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1.2 * hero_atk)) * 1 * 1.871",
                 "simplified": "((2.2452 * hero_atk))",
-                "soulburn": "((1.2 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1.2 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((2.2452 * hero_atk))"
             }
         },

--- a/src/hero/challenger-dominiel.json
+++ b/src/hero/challenger-dominiel.json
@@ -203,10 +203,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * (1 + (([0.054, 0.0702] * hero_special_count))) * 0.9 * 1.871",
-                "simplified": "((1.6839 * hero_atk)) * (1 + (([0.054, 0.0702] * hero_special_count)))",
-                "soulburn": "((2.5 * hero_atk)) * (1 + (([0.054, 0.0702] * hero_special_count))) * 1.0 * 1.871",
-                "simplifiedSoulburn": "((4.6775 * hero_atk)) * (1 + (([0.054, 0.0702] * hero_special_count)))"
+                "value": "((1 * hero_atk)) * (1 + ((skill_dmg_rate[0.054, 0.0702] * hero_special_count))) * 0.9 * 1.871",
+                "simplified": "((1.6839 * hero_atk)) * (1 + ((skill_dmg_rate[0.054, 0.0702] * hero_special_count)))",
+                "soulburn": "((2.5 * hero_atk)) * (1 + ((skill_dmg_rate[0.054, 0.0702] * hero_special_count))) * 1 * 1.871",
+                "simplifiedSoulburn": "((4.2097 * hero_atk)) * (1 + ((skill_dmg_rate[0.054, 0.0702] * hero_special_count)))"
             }
         },
         {

--- a/src/hero/champion-zerato.json
+++ b/src/hero/champion-zerato.json
@@ -211,9 +211,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 0.95 * 1.871",
+                "value": "((1 * hero_atk)) * 0.95 * 1.871",
                 "simplified": "((1.7774 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 0.95 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 0.95 * 1.871",
                 "simplifiedSoulburn": "((1.7774 * hero_atk))"
             }
         },
@@ -427,9 +427,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         }

--- a/src/hero/chaos-inquisitor.json
+++ b/src/hero/chaos-inquisitor.json
@@ -211,9 +211,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },

--- a/src/hero/chaos-sect-axe.json
+++ b/src/hero/chaos-sect-axe.json
@@ -188,9 +188,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((target_hp_missing_rate * target_hp_lost_percent))) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * (1 + ((0.002 * target_hp_lost_percent))) * 0.95 * 1.871",
+                "value": "((1 * hero_atk)) * (1 + ((0.002 * target_hp_lost_percent))) * 0.95 * 1.871",
                 "simplified": "((1.7774 * hero_atk)) * (1 + ((0.002 * target_hp_lost_percent)))",
-                "soulburn": "((1.0 * hero_atk)) * (1 + ((0.002 * target_hp_lost_percent))) * 0.95 * 1.871",
+                "soulburn": "((1 * hero_atk)) * (1 + ((0.002 * target_hp_lost_percent))) * 0.95 * 1.871",
                 "simplifiedSoulburn": "((1.7774 * hero_atk)) * (1 + ((0.002 * target_hp_lost_percent)))"
             }
         },
@@ -293,7 +293,7 @@
                 "description": "((atk_rate * hero_atk)) * (1 + ((target_hp_missing_rate * target_hp_lost_percent))) * pow! * constant",
                 "value": "((0.8 * hero_atk)) * (1 + ((0.005 * target_hp_lost_percent))) * 0.95 * 1.871",
                 "simplified": "((1.422 * hero_atk)) * (1 + ((0.005 * target_hp_lost_percent)))",
-                "soulburn": "((1.0 * hero_atk)) * (1 + ((0.005 * target_hp_lost_percent))) * 0.95 * 1.871",
+                "soulburn": "((1 * hero_atk)) * (1 + ((0.005 * target_hp_lost_percent))) * 0.95 * 1.871",
                 "simplifiedSoulburn": "((1.7774 * hero_atk)) * (1 + ((0.005 * target_hp_lost_percent)))"
             }
         },

--- a/src/hero/charles.json
+++ b/src/hero/charles.json
@@ -200,9 +200,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -325,10 +325,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "(([1.5, 1.57, 1.64, 1.71, 1.78, 1.85] * hero_atk)) * 1.0 * 1.871",
-                "simplified": "(([2.8065, 2.9375, 3.0684, 3.1994, 3.3304, 3.4614] * hero_atk))",
-                "soulburn": "(([1.5, 1.57, 1.64, 1.71, 1.78, 1.85] * hero_atk)) * 1.0 * 1.871",
-                "simplifiedSoulburn": "(([2.8065, 2.9375, 3.0684, 3.1994, 3.3304, 3.4614] * hero_atk))"
+                "value": "((atk_rate[1.5, 1.57, 1.64, 1.71, 1.78, 1.85] * hero_atk)) * 1 * 1.871",
+                "simplified": "((atk_rate[2.8065, 2.9375, 3.0684, 3.1994, 3.3304, 3.4614] * hero_atk))",
+                "soulburn": "((atk_rate[1.5, 1.57, 1.64, 1.71, 1.78, 1.85] * hero_atk)) * 1 * 1.871",
+                "simplifiedSoulburn": "((atk_rate[2.8065, 2.9375, 3.0684, 3.1994, 3.3304, 3.4614] * hero_atk))"
             }
         },
         {
@@ -452,11 +452,11 @@
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_list))) * pow! * constant",
-                "value": "((1.2 * hero_atk)) * (1 + (([1.068, 0.801, 0.534]))) * 1.0 * 1.871",
-                "simplified": "((2.2452 * hero_atk)) * (1 + (([1.068, 0.801, 0.534])))",
-                "soulburn": "((1.2 * hero_atk)) * (1 + (([1.068, 0.801, 0.534]))) * 1.0 * 1.871",
-                "simplifiedSoulburn": "((2.2452 * hero_atk)) * (1 + (([1.068, 0.801, 0.534])))"
+                "description": "((atk_rate * hero_atk)) * (1 + (skill_dmg_list)) * pow! * constant",
+                "value": "((1.2 * hero_atk)) * (1 + (skill_dmg_list[1.068, 0.801, 0.534])) * 1 * 1.871",
+                "simplified": "((2.2452 * hero_atk)) * (1 + (skill_dmg_list[1.068, 0.801, 0.534]))",
+                "soulburn": "((1.2 * hero_atk)) * (1 + (skill_dmg_list[1.068, 0.801, 0.534])) * 1 * 1.871",
+                "simplifiedSoulburn": "((2.2452 * hero_atk)) * (1 + (skill_dmg_list[1.068, 0.801, 0.534]))"
             }
         }
     ],

--- a/src/hero/charles.json
+++ b/src/hero/charles.json
@@ -437,14 +437,16 @@
                     "soulburn": 1.2
                 },
                 {
-                    "name": "skill_dmg_list",
+                    "name": "targets_rate",
                     "description": "Increases damage per target.",
                     "value": [
+                        0,
                         1.068,
                         0.801,
                         0.534
                     ],
                     "soulburn": [
+                        0,
                         1.068,
                         0.801,
                         0.534
@@ -452,11 +454,11 @@
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + (skill_dmg_list)) * pow! * constant",
-                "value": "((1.2 * hero_atk)) * (1 + (skill_dmg_list[1.068, 0.801, 0.534])) * 1 * 1.871",
-                "simplified": "((2.2452 * hero_atk)) * (1 + (skill_dmg_list[1.068, 0.801, 0.534]))",
-                "soulburn": "((1.2 * hero_atk)) * (1 + (skill_dmg_list[1.068, 0.801, 0.534])) * 1 * 1.871",
-                "simplifiedSoulburn": "((2.2452 * hero_atk)) * (1 + (skill_dmg_list[1.068, 0.801, 0.534]))"
+                "description": "((atk_rate * hero_atk)) * (1 + (targets_rate)) * pow! * constant",
+                "value": "((1.2 * hero_atk)) * (1 + ((targets_rate[0, 1.068, 0.801, 0.534]))) * 1 * 1.871",
+                "simplified": "((2.2452 * hero_atk)) * (1 + ((targets_rate[0, 1.068, 0.801, 0.534])))",
+                "soulburn": "((1.2 * hero_atk)) * (1 + ((targets_rate[0, 1.068, 0.801, 0.534]))) * 1 * 1.871",
+                "simplifiedSoulburn": "((2.2452 * hero_atk)) * (1 + ((targets_rate[0, 1.068, 0.801, 0.534])))"
             }
         }
     ],

--- a/src/hero/charlotte.json
+++ b/src/hero/charlotte.json
@@ -194,9 +194,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -307,9 +307,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.8 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.8 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.4968 * hero_atk))",
-                "soulburn": "((0.8 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((0.8 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.4968 * hero_atk))"
             }
         },
@@ -433,10 +433,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "(([0.8, 0.8, 1, 1.3, 1.7, 2.4] * hero_atk)) * 0.8 * 1.871",
-                "simplified": "(([1.1974, 1.1974, 1.4968, 1.9458, 2.5446, 3.5923] * hero_atk))",
-                "soulburn": "(([0.8, 0.8, 1, 1.3, 1.7, 2.4] * hero_atk)) * 0.8 * 1.871",
-                "simplifiedSoulburn": "(([1.1974, 1.1974, 1.4968, 1.9458, 2.5446, 3.5923] * hero_atk))"
+                "value": "((atk_rate[0.8, 0.8, 1, 1.3, 1.7, 2.4] * hero_atk)) * 0.8 * 1.871",
+                "simplified": "((atk_rate[1.1974, 1.1974, 1.4968, 1.9458, 2.5446, 3.5923] * hero_atk))",
+                "soulburn": "((atk_rate[0.8, 0.8, 1, 1.3, 1.7, 2.4] * hero_atk)) * 0.8 * 1.871",
+                "simplifiedSoulburn": "((atk_rate[1.1974, 1.1974, 1.4968, 1.9458, 2.5446, 3.5923] * hero_atk))"
             }
         }
     ],

--- a/src/hero/chloe.json
+++ b/src/hero/chloe.json
@@ -200,9 +200,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * (1 + ((0.3 * hero_special_count))) * 0.9 * 1.871",
+                "value": "((1 * hero_atk)) * (1 + ((0.3 * hero_special_count))) * 0.9 * 1.871",
                 "simplified": "((1.6839 * hero_atk)) * (1 + ((0.3 * hero_special_count)))",
-                "soulburn": "((1.0 * hero_atk)) * (1 + ((0.3 * hero_special_count))) * 0.9 * 1.871",
+                "soulburn": "((1 * hero_atk)) * (1 + ((0.3 * hero_special_count))) * 0.9 * 1.871",
                 "simplifiedSoulburn": "((1.6839 * hero_atk)) * (1 + ((0.3 * hero_special_count)))"
             }
         },
@@ -432,7 +432,7 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((2.0 * hero_atk)) * (1 + ((0.35 * hero_special_count))) * 0.8 * 1.871",
+                "value": "((2 * hero_atk)) * (1 + ((0.35 * hero_special_count))) * 0.8 * 1.871",
                 "simplified": "((2.9936 * hero_atk)) * (1 + ((0.35 * hero_special_count)))",
                 "soulburn": "((3.5 * hero_atk)) * (1 + ((0.35 * hero_special_count))) * 0.8 * 1.871",
                 "simplifiedSoulburn": "((5.2388 * hero_atk)) * (1 + ((0.35 * hero_special_count)))"

--- a/src/hero/chloe.json
+++ b/src/hero/chloe.json
@@ -192,18 +192,18 @@
                     "soulburn": 1
                 },
                 {
-                    "name": "skill_dmg_rate",
-                    "description": "If target is inflicted with Magic Nail.",
+                    "name": "target_buff_rate",
+                    "description": "If target is inflicted with Magic Nail. Max once.",
                     "value": 0.3,
                     "soulburn": 0.3
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((1 * hero_atk)) * (1 + ((0.3 * hero_special_count))) * 0.9 * 1.871",
-                "simplified": "((1.6839 * hero_atk)) * (1 + ((0.3 * hero_special_count)))",
-                "soulburn": "((1 * hero_atk)) * (1 + ((0.3 * hero_special_count))) * 0.9 * 1.871",
-                "simplifiedSoulburn": "((1.6839 * hero_atk)) * (1 + ((0.3 * hero_special_count)))"
+                "description": "((atk_rate * hero_atk)) * (1 + ((target_buff_rate * target_buffs))) * pow! * constant",
+                "value": "((1 * hero_atk)) * (1 + ((0.3 * target_buffs))) * 0.9 * 1.871",
+                "simplified": "((1.6839 * hero_atk)) * (1 + ((0.3 * target_buffs)))",
+                "soulburn": "((1 * hero_atk)) * (1 + ((0.3 * target_buffs))) * 0.9 * 1.871",
+                "simplifiedSoulburn": "((1.6839 * hero_atk)) * (1 + ((0.3 * target_buffs)))"
             }
         },
         {
@@ -424,18 +424,18 @@
                     "soulburn": 3.5
                 },
                 {
-                    "name": "skill_dmg_rate",
-                    "description": "If target is inflicted with Magic Nail.",
+                    "name": "target_buff_rate",
+                    "description": "If target is inflicted with Magic Nail. Max once.",
                     "value": 0.35,
                     "soulburn": 0.35
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((2 * hero_atk)) * (1 + ((0.35 * hero_special_count))) * 0.8 * 1.871",
-                "simplified": "((2.9936 * hero_atk)) * (1 + ((0.35 * hero_special_count)))",
-                "soulburn": "((3.5 * hero_atk)) * (1 + ((0.35 * hero_special_count))) * 0.8 * 1.871",
-                "simplifiedSoulburn": "((5.2388 * hero_atk)) * (1 + ((0.35 * hero_special_count)))"
+                "description": "((atk_rate * hero_atk)) * (1 + ((target_buff_rate * target_buffs))) * pow! * constant",
+                "value": "((2 * hero_atk)) * (1 + ((0.35 * target_buffs))) * 0.8 * 1.871",
+                "simplified": "((2.9936 * hero_atk)) * (1 + ((0.35 * target_buffs)))",
+                "soulburn": "((3.5 * hero_atk)) * (1 + ((0.35 * target_buffs))) * 0.8 * 1.871",
+                "simplifiedSoulburn": "((5.2388 * hero_atk)) * (1 + ((0.35 * target_buffs)))"
             }
         }
     ],

--- a/src/hero/church-of-ilryos-axe.json
+++ b/src/hero/church-of-ilryos-axe.json
@@ -188,9 +188,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((target_hp_missing_rate * target_hp_lost_percent))) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * (1 + ((0.002 * target_hp_lost_percent))) * 0.95 * 1.871",
+                "value": "((1 * hero_atk)) * (1 + ((0.002 * target_hp_lost_percent))) * 0.95 * 1.871",
                 "simplified": "((1.7774 * hero_atk)) * (1 + ((0.002 * target_hp_lost_percent)))",
-                "soulburn": "((1.0 * hero_atk)) * (1 + ((0.002 * target_hp_lost_percent))) * 0.95 * 1.871",
+                "soulburn": "((1 * hero_atk)) * (1 + ((0.002 * target_hp_lost_percent))) * 0.95 * 1.871",
                 "simplifiedSoulburn": "((1.7774 * hero_atk)) * (1 + ((0.002 * target_hp_lost_percent)))"
             }
         },
@@ -293,7 +293,7 @@
                 "description": "((atk_rate * hero_atk)) * (1 + ((target_hp_missing_rate * target_hp_lost_percent))) * pow! * constant",
                 "value": "((0.8 * hero_atk)) * (1 + ((0.005 * target_hp_lost_percent))) * 0.95 * 1.871",
                 "simplified": "((1.422 * hero_atk)) * (1 + ((0.005 * target_hp_lost_percent)))",
-                "soulburn": "((1.0 * hero_atk)) * (1 + ((0.005 * target_hp_lost_percent))) * 0.95 * 1.871",
+                "soulburn": "((1 * hero_atk)) * (1 + ((0.005 * target_hp_lost_percent))) * 0.95 * 1.871",
                 "simplifiedSoulburn": "((1.7774 * hero_atk)) * (1 + ((0.005 * target_hp_lost_percent)))"
             }
         },

--- a/src/hero/cidd.json
+++ b/src/hero/cidd.json
@@ -211,10 +211,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((spd_rate * hero_spd))) * pow! * constant",
-                "value": "(([0.9, 1.05] * hero_atk)) * (1 + ((0.00075 * hero_spd))) * [0.95, 1.35] * 1.871",
-                "simplified": "(([1.6839, 1.9646] * [1.7774, 2.5259] * hero_atk)) * (1 + ((0.00075 * hero_spd)))",
-                "soulburn": "(([0.9, 1.05] * hero_atk)) * (1 + ((0.00075 * hero_spd))) * [0.95, 1.35] * 1.871",
-                "simplifiedSoulburn": "(([1.6839, 1.9646] * [1.7774, 2.5259] * hero_atk)) * (1 + ((0.00075 * hero_spd)))"
+                "value": "((atk_rate[0.9, 1.05] * hero_atk)) * (1 + ((0.00075 * hero_spd))) * pow![0.95, 1.35] * 1.871",
+                "simplified": "((S2Active[1.5997, 2.6521] * hero_atk)) * (1 + ((0.00075 * hero_spd)))",
+                "soulburn": "((atk_rate[0.9, 1.05] * hero_atk)) * (1 + ((0.00075 * hero_spd))) * pow![0.95, 1.35] * 1.871",
+                "simplifiedSoulburn": "((S2Active[1.5997, 2.6521] * hero_atk)) * (1 + ((0.00075 * hero_spd)))"
             }
         },
         {
@@ -438,9 +438,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((spd_rate * hero_spd))) * pow! * constant",
-                "value": "((1.6 * hero_atk)) * (1 + ((0.0021 * hero_spd))) * 1.0 * 1.871",
+                "value": "((1.6 * hero_atk)) * (1 + ((0.0021 * hero_spd))) * 1 * 1.871",
                 "simplified": "((2.9936 * hero_atk)) * (1 + ((0.0021 * hero_spd)))",
-                "soulburn": "((2.2 * hero_atk)) * (1 + ((0.0021 * hero_spd))) * 1.0 * 1.871",
+                "soulburn": "((2.2 * hero_atk)) * (1 + ((0.0021 * hero_spd))) * 1 * 1.871",
                 "simplifiedSoulburn": "((4.1162 * hero_atk)) * (1 + ((0.0021 * hero_spd)))"
             }
         }

--- a/src/hero/clarissa.json
+++ b/src/hero/clarissa.json
@@ -200,9 +200,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -311,9 +311,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.7 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.7 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.3097 * hero_atk))",
-                "soulburn": "((0.7 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((0.7 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.3097 * hero_atk))"
             }
         },
@@ -430,9 +430,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((0.8 * hero_atk)) * (1 + ((0.3 * hero_special_count))) * 1.0 * 1.871",
+                "value": "((0.8 * hero_atk)) * (1 + ((0.3 * hero_special_count))) * 1 * 1.871",
                 "simplified": "((1.4968 * hero_atk)) * (1 + ((0.3 * hero_special_count)))",
-                "soulburn": "((1.05 * hero_atk)) * (1 + ((0.3 * hero_special_count))) * 1.0 * 1.871",
+                "soulburn": "((1.05 * hero_atk)) * (1 + ((0.3 * hero_special_count))) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.9646 * hero_atk)) * (1 + ((0.3 * hero_special_count)))"
             }
         }

--- a/src/hero/commander-lorina.json
+++ b/src/hero/commander-lorina.json
@@ -194,9 +194,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 0.9 * 1.871",
+                "value": "((1 * hero_atk)) * 0.9 * 1.871",
                 "simplified": "((1.6839 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 0.9 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 0.9 * 1.871",
                 "simplifiedSoulburn": "((1.6839 * hero_atk))"
             }
         },

--- a/src/hero/corvus.json
+++ b/src/hero/corvus.json
@@ -234,10 +234,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (def_rate * hero_def)) * pow! * constant",
-                "value": "(([0.7, 0.9] * hero_atk) + ([0.9, 1.2] * hero_def)) * 1.0 * 1.871",
-                "simplified": "(([1.3097, 1.6839] * hero_atk) + ([1.6839, 2.2452] * hero_def))",
-                "soulburn": "(([0.7, 0.9] * hero_atk) + ([0.9, 1.2] * hero_def)) * 1.0 * 1.871",
-                "simplifiedSoulburn": "(([1.3097, 1.6839] * hero_atk) + ([1.6839, 2.2452] * hero_def))"
+                "value": "((atk_rate[0.7, 0.9] * hero_atk) + (def_rate[0.9, 1.2] * hero_def)) * 1 * 1.871",
+                "simplified": "((atk_rate[1.3097, 1.6839] * hero_atk) + (def_rate[1.6839, 2.2452] * hero_def))",
+                "soulburn": "((atk_rate[0.7, 0.9] * hero_atk) + (def_rate[0.9, 1.2] * hero_def)) * 1 * 1.871",
+                "simplifiedSoulburn": "((atk_rate[1.3097, 1.6839] * hero_atk) + (def_rate[1.6839, 2.2452] * hero_def))"
             }
         },
         {

--- a/src/hero/crescent-moon-rin.json
+++ b/src/hero/crescent-moon-rin.json
@@ -195,9 +195,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -306,9 +306,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.1 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1.1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((2.0581 * hero_atk))",
-                "soulburn": "((1.1 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1.1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((2.0581 * hero_atk))"
             }
         },
@@ -419,9 +419,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.6 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1.6 * hero_atk)) * 1 * 1.871",
                 "simplified": "((2.9936 * hero_atk))",
-                "soulburn": "((1.6 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1.6 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((2.9936 * hero_atk))"
             }
         }

--- a/src/hero/crimson-armin.json
+++ b/src/hero/crimson-armin.json
@@ -210,9 +210,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (def_rate * hero_def)) * pow! * constant",
-                "value": "((0.8 * hero_atk) + (0.6 * hero_def)) * 1.0 * 1.871",
+                "value": "((0.8 * hero_atk) + (0.6 * hero_def)) * 1 * 1.871",
                 "simplified": "((1.4968 * hero_atk) + (1.1226 * hero_def))",
-                "soulburn": "((0.8 * hero_atk) + (0.6 * hero_def)) * 1.0 * 1.871",
+                "soulburn": "((0.8 * hero_atk) + (0.6 * hero_def)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.4968 * hero_atk) + (1.1226 * hero_def))"
             }
         },

--- a/src/hero/dark-corvus.json
+++ b/src/hero/dark-corvus.json
@@ -218,9 +218,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (hp_rate * hero_hp)) * pow! * constant",
-                "value": "((0.7 * hero_atk) + (0.07 * hero_hp)) * 1.0 * 1.871",
+                "value": "((0.7 * hero_atk) + (0.07 * hero_hp)) * 1 * 1.871",
                 "simplified": "((1.3097 * hero_atk) + (0.131 * hero_hp))",
-                "soulburn": "((0.7 * hero_atk) + (0.07 * hero_hp)) * 1.0 * 1.871",
+                "soulburn": "((0.7 * hero_atk) + (0.07 * hero_hp)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.3097 * hero_atk) + (0.131 * hero_hp))"
             }
         },

--- a/src/hero/destina.json
+++ b/src/hero/destina.json
@@ -215,9 +215,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },

--- a/src/hero/diene.json
+++ b/src/hero/diene.json
@@ -236,9 +236,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 0.95 * 1.871",
+                "value": "((1 * hero_atk)) * 0.95 * 1.871",
                 "simplified": "((1.7774 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 0.95 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 0.95 * 1.871",
                 "simplifiedSoulburn": "((1.7774 * hero_atk))"
             }
         },

--- a/src/hero/dingo.json
+++ b/src/hero/dingo.json
@@ -205,9 +205,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -348,9 +348,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.8 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.8 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.4968 * hero_atk))",
-                "soulburn": "((0.8 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((0.8 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.4968 * hero_atk))"
             }
         },

--- a/src/hero/dingo.json
+++ b/src/hero/dingo.json
@@ -106,7 +106,7 @@
                     ]
                 },
                 {
-                    "description": "+5 damage dealt",
+                    "description": "+5% damage dealt",
                     "resources": [
                         {
                             "item": "gold",

--- a/src/hero/dizzy.json
+++ b/src/hero/dizzy.json
@@ -202,9 +202,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((0.7 * hero_atk)) * (1 + ((0.3 * hero_special_count))) * 1.0 * 1.871",
+                "value": "((0.7 * hero_atk)) * (1 + ((0.3 * hero_special_count))) * 1 * 1.871",
                 "simplified": "((1.3097 * hero_atk)) * (1 + ((0.3 * hero_special_count)))",
-                "soulburn": "((0.7 * hero_atk)) * (1 + ((0.3 * hero_special_count))) * 1.0 * 1.871",
+                "soulburn": "((0.7 * hero_atk)) * (1 + ((0.3 * hero_special_count))) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.3097 * hero_atk)) * (1 + ((0.3 * hero_special_count)))"
             }
         },
@@ -313,9 +313,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -428,9 +428,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((2.5 * hero_atk)) * 1.0 * 1.871",
+                "value": "((2.5 * hero_atk)) * 1 * 1.871",
                 "simplified": "((4.6775 * hero_atk))",
-                "soulburn": "((2.5 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((2.5 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((4.6775 * hero_atk))"
             }
         }

--- a/src/hero/dizzy.json
+++ b/src/hero/dizzy.json
@@ -194,18 +194,18 @@
                     "soulburn": 0.7
                 },
                 {
-                    "name": "skill_dmg_rate",
-                    "description": "If target has a debuffs",
+                    "name": "target_debuff_rate",
+                    "description": "If target has a debuff. Max increase, once.",
                     "value": 0.3,
                     "soulburn": 0.3
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((0.7 * hero_atk)) * (1 + ((0.3 * hero_special_count))) * 1 * 1.871",
-                "simplified": "((1.3097 * hero_atk)) * (1 + ((0.3 * hero_special_count)))",
-                "soulburn": "((0.7 * hero_atk)) * (1 + ((0.3 * hero_special_count))) * 1 * 1.871",
-                "simplifiedSoulburn": "((1.3097 * hero_atk)) * (1 + ((0.3 * hero_special_count)))"
+                "description": "((atk_rate * hero_atk)) * (1 + ((target_debuff_rate * target_num_debuffs))) * pow! * constant",
+                "value": "((0.7 * hero_atk)) * (1 + ((0.3 * target_num_debuffs))) * 1 * 1.871",
+                "simplified": "((1.3097 * hero_atk)) * (1 + ((0.3 * target_num_debuffs)))",
+                "soulburn": "((0.7 * hero_atk)) * (1 + ((0.3 * target_num_debuffs))) * 1 * 1.871",
+                "simplifiedSoulburn": "((1.3097 * hero_atk)) * (1 + ((0.3 * target_num_debuffs)))"
             }
         },
         {

--- a/src/hero/dizzy.json
+++ b/src/hero/dizzy.json
@@ -201,11 +201,11 @@
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((target_debuff_rate * target_num_debuffs))) * pow! * constant",
-                "value": "((0.7 * hero_atk)) * (1 + ((0.3 * target_num_debuffs))) * 1 * 1.871",
-                "simplified": "((1.3097 * hero_atk)) * (1 + ((0.3 * target_num_debuffs)))",
-                "soulburn": "((0.7 * hero_atk)) * (1 + ((0.3 * target_num_debuffs))) * 1 * 1.871",
-                "simplifiedSoulburn": "((1.3097 * hero_atk)) * (1 + ((0.3 * target_num_debuffs)))"
+                "description": "((atk_rate * hero_atk)) * (1 + ((target_debuff_rate * target_debuffs))) * pow! * constant",
+                "value": "((0.7 * hero_atk)) * (1 + ((0.3 * target_debuffs))) * 1 * 1.871",
+                "simplified": "((1.3097 * hero_atk)) * (1 + ((0.3 * target_debuffs)))",
+                "soulburn": "((0.7 * hero_atk)) * (1 + ((0.3 * target_debuffs))) * 1 * 1.871",
+                "simplifiedSoulburn": "((1.3097 * hero_atk)) * (1 + ((0.3 * target_debuffs)))"
             }
         },
         {

--- a/src/hero/dominiel.json
+++ b/src/hero/dominiel.json
@@ -209,9 +209,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },

--- a/src/hero/doris.json
+++ b/src/hero/doris.json
@@ -192,9 +192,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },

--- a/src/hero/elson.json
+++ b/src/hero/elson.json
@@ -209,9 +209,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.9 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.9 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.6839 * hero_atk))",
-                "soulburn": "((0.9 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((0.9 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.6839 * hero_atk))"
             }
         },

--- a/src/hero/enott.json
+++ b/src/hero/enott.json
@@ -197,9 +197,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((target_hp_missing_rate * target_hp_lost_percent))) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * (1 + ((0.005 * target_hp_lost_percent))) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * (1 + ((0.005 * target_hp_lost_percent))) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk)) * (1 + ((0.005 * target_hp_lost_percent)))",
-                "soulburn": "((1.0 * hero_atk)) * (1 + ((0.005 * target_hp_lost_percent))) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * (1 + ((0.005 * target_hp_lost_percent))) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk)) * (1 + ((0.005 * target_hp_lost_percent)))"
             }
         },

--- a/src/hero/fallen-cecilia.json
+++ b/src/hero/fallen-cecilia.json
@@ -193,9 +193,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (hp_rate * hero_hp)) * pow! * constant",
-                "value": "((0.7 * hero_atk) + (0.07 * hero_hp)) * 1.0 * 1.871",
+                "value": "((0.7 * hero_atk) + (0.07 * hero_hp)) * 1 * 1.871",
                 "simplified": "((1.3097 * hero_atk) + (0.131 * hero_hp))",
-                "soulburn": "((0.7 * hero_atk) + (0.07 * hero_hp)) * 1.0 * 1.871",
+                "soulburn": "((0.7 * hero_atk) + (0.07 * hero_hp)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.3097 * hero_atk) + (0.131 * hero_hp))"
             }
         },

--- a/src/hero/fighter-maya.json
+++ b/src/hero/fighter-maya.json
@@ -193,9 +193,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (def_rate * hero_def)) * pow! * constant",
-                "value": "((0.5 * hero_atk) + (0.75 * hero_def)) * 1.0 * 1.871",
+                "value": "((0.5 * hero_atk) + (0.75 * hero_def)) * 1 * 1.871",
                 "simplified": "((0.9355 * hero_atk) + (1.4032 * hero_def))",
-                "soulburn": "((0.5 * hero_atk) + (0.75 * hero_def)) * 1.0 * 1.871",
+                "soulburn": "((0.5 * hero_atk) + (0.75 * hero_def)) * 1 * 1.871",
                 "simplifiedSoulburn": "((0.9355 * hero_atk) + (1.4032 * hero_def))"
             }
         },
@@ -422,9 +422,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (def_rate * hero_def)) * pow! * constant",
-                "value": "((1.0 * hero_atk) + (1.5 * hero_def)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk) + (1.5 * hero_def)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk) + (2.8065 * hero_def))",
-                "soulburn": "((1.7 * hero_atk) + (1.5 * hero_def)) * 1.0 * 1.871",
+                "soulburn": "((1.7 * hero_atk) + (1.5 * hero_def)) * 1 * 1.871",
                 "simplifiedSoulburn": "((3.1807 * hero_atk) + (2.8065 * hero_def))"
             }
         }

--- a/src/hero/furious.json
+++ b/src/hero/furious.json
@@ -216,21 +216,23 @@
             "damageModifiers": [
                 {
                     "name": "pow",
-                    "section": "pow",
                     "value": 1,
                     "soulburn": 1
                 },
                 {
-                    "name": "statModifier",
+                    "name": "atk_rate",
                     "description": "",
-                    "section": "additive",
-                    "stat": "atk",
-                    "type": "multiplier",
-                    "target": "self",
                     "value": 1,
                     "soulburn": 1
                 }
-            ]
+            ],
+            "simpleDmgMod": {
+                "description": "((atk_rate * hero_atk)) * pow! * constant",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
+                "simplified": "((1.871 * hero_atk))",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
+                "simplifiedSoulburn": "((1.871 * hero_atk))"
+            }
         },
         {
             "isPassive": false,
@@ -268,21 +270,23 @@
             "damageModifiers": [
                 {
                     "name": "pow",
-                    "section": "pow",
                     "value": 0,
                     "soulburn": 0
                 },
                 {
-                    "name": "statModifier",
+                    "name": "atk_rate",
                     "description": "",
-                    "section": "additive",
-                    "stat": "atk",
-                    "type": "multiplier",
-                    "target": "self",
                     "value": 0,
                     "soulburn": 0
                 }
-            ]
+            ],
+            "simpleDmgMod": {
+                "description": "",
+                "value": "",
+                "simplified": "",
+                "soulburn": "",
+                "simplifiedSoulburn": ""
+            }
         },
         {
             "isPassive": false,
@@ -410,21 +414,23 @@
             "damageModifiers": [
                 {
                     "name": "pow",
-                    "section": "pow",
                     "value": 1,
                     "soulburn": 1
                 },
                 {
-                    "name": "statModifier",
+                    "name": "atk_rate",
                     "description": "",
-                    "section": "additive",
-                    "stat": "atk",
-                    "type": "multiplier",
-                    "target": "self",
                     "value": 1.65,
                     "soulburn": 1.95
                 }
-            ]
+            ],
+            "simpleDmgMod": {
+                "description": "((atk_rate * hero_atk)) * pow! * constant",
+                "value": "((1.65 * hero_atk)) * 1 * 1.871",
+                "simplified": "((3.0871 * hero_atk))",
+                "soulburn": "((1.95 * hero_atk)) * 1 * 1.871",
+                "simplifiedSoulburn": "((3.6484 * hero_atk))"
+            }
         }
     ],
     "specialtySkill": {

--- a/src/hero/general-purrgis.json
+++ b/src/hero/general-purrgis.json
@@ -213,9 +213,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -430,9 +430,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.8 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.8 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.4968 * hero_atk))",
-                "soulburn": "((0.8 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((0.8 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.4968 * hero_atk))"
             }
         }

--- a/src/hero/gloomyrain.json
+++ b/src/hero/gloomyrain.json
@@ -220,10 +220,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "(([1.0, 1.25, 1.4] * hero_atk)) * 0.95 * 1.871",
-                "simplified": "(([1.7774, 2.2218, 2.4884] * hero_atk))",
-                "soulburn": "(([1.0, 1.25, 1.4] * hero_atk)) * 0.95 * 1.871",
-                "simplifiedSoulburn": "(([1.7774, 2.2218, 2.4884] * hero_atk))"
+                "value": "((atk_rate[1, 1.25, 1.4] * hero_atk)) * 0.95 * 1.871",
+                "simplified": "((atk_rate[1.7774, 2.2218, 2.4884] * hero_atk))",
+                "soulburn": "((atk_rate[1, 1.25, 1.4] * hero_atk)) * 0.95 * 1.871",
+                "simplifiedSoulburn": "((atk_rate[1.7774, 2.2218, 2.4884] * hero_atk))"
             }
         },
         {
@@ -442,10 +442,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "(([0.7, 0.95, 1.1] * hero_atk)) * 1.0 * 1.871",
-                "simplified": "(([1.3097, 1.7774, 2.0581] * hero_atk))",
-                "soulburn": "(([0.95, 1.2, 1.35] * hero_atk)) * 1.0 * 1.871",
-                "simplifiedSoulburn": "(([1.7774, 2.2452, 2.5259] * hero_atk))"
+                "value": "((atk_rate[0.7, 0.95, 1.1] * hero_atk)) * 1 * 1.871",
+                "simplified": "((atk_rate[1.3097, 1.7774, 2.0581] * hero_atk))",
+                "soulburn": "((atk_rate[0.95, 1.2, 1.35] * hero_atk)) * 1 * 1.871",
+                "simplifiedSoulburn": "((atk_rate[1.7774, 2.2452, 2.5259] * hero_atk))"
             }
         }
     ],

--- a/src/hero/guider-aither.json
+++ b/src/hero/guider-aither.json
@@ -204,9 +204,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },

--- a/src/hero/gunther.json
+++ b/src/hero/gunther.json
@@ -419,18 +419,18 @@
                     "soulburn": 2.4
                 },
                 {
-                    "name": "skill_dmg_rate",
-                    "description": "Increased damage if target is bleeding.",
+                    "name": "target_debuff_rate",
+                    "description": "Increased damage if target is bleeding. Max once.",
                     "value": 0.3,
                     "soulburn": 0.3
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((1.7 * hero_atk)) * (1 + ((0.3 * hero_special_count))) * 0.95 * 1.871",
-                "simplified": "((3.0217 * hero_atk)) * (1 + ((0.3 * hero_special_count)))",
-                "soulburn": "((2.4 * hero_atk)) * (1 + ((0.3 * hero_special_count))) * 0.95 * 1.871",
-                "simplifiedSoulburn": "((4.2659 * hero_atk)) * (1 + ((0.3 * hero_special_count)))"
+                "description": "((atk_rate * hero_atk)) * (1 + ((target_debuff_rate * target_debuffs))) * pow! * constant",
+                "value": "((1.7 * hero_atk)) * (1 + ((0.3 * target_debuffs))) * 0.95 * 1.871",
+                "simplified": "((3.0217 * hero_atk)) * (1 + ((0.3 * target_debuffs)))",
+                "soulburn": "((2.4 * hero_atk)) * (1 + ((0.3 * target_debuffs))) * 0.95 * 1.871",
+                "simplifiedSoulburn": "((4.2659 * hero_atk)) * (1 + ((0.3 * target_debuffs)))"
             }
         }
     ],

--- a/src/hero/gunther.json
+++ b/src/hero/gunther.json
@@ -196,9 +196,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 0.85 * 1.871",
+                "value": "((1 * hero_atk)) * 0.85 * 1.871",
                 "simplified": "((1.5903 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 0.85 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 0.85 * 1.871",
                 "simplifiedSoulburn": "((1.5903 * hero_atk))"
             }
         },

--- a/src/hero/haste.json
+++ b/src/hero/haste.json
@@ -192,9 +192,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -306,9 +306,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.5 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1.5 * hero_atk)) * 1 * 1.871",
                 "simplified": "((2.8065 * hero_atk))",
-                "soulburn": "((2.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((2 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((3.742 * hero_atk))"
             }
         },
@@ -431,11 +431,11 @@
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_list))) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * (1 + (([2.5, 2.0, 0.0]))) * 1.0 * 1.871",
-                "simplified": "((1.871 * hero_atk)) * (1 + (([2.5, 2.0, 0.0])))",
-                "soulburn": "((1.0 * hero_atk)) * (1 + (([2.5, 2.0, 0.0]))) * 1.0 * 1.871",
-                "simplifiedSoulburn": "((1.871 * hero_atk)) * (1 + (([2.5, 2.0, 0.0])))"
+                "description": "((atk_rate * hero_atk)) * (1 + (skill_dmg_list)) * pow! * constant",
+                "value": "((1 * hero_atk)) * (1 + (skill_dmg_list[2.5, 2, 0])) * 1 * 1.871",
+                "simplified": "((1.871 * hero_atk)) * (1 + (skill_dmg_list[2.5, 2, 0]))",
+                "soulburn": "((1 * hero_atk)) * (1 + (skill_dmg_list[2.5, 2, 0])) * 1 * 1.871",
+                "simplifiedSoulburn": "((1.871 * hero_atk)) * (1 + (skill_dmg_list[2.5, 2, 0]))"
             }
         }
     ],

--- a/src/hero/haste.json
+++ b/src/hero/haste.json
@@ -417,13 +417,15 @@
                     "soulburn": 1
                 },
                 {
-                    "name": "skill_dmg_list",
+                    "name": "targets_rate",
                     "value": [
+                        0,
                         2.5,
                         2,
                         0
                     ],
                     "soulburn": [
+                        0,
                         2.5,
                         2,
                         0
@@ -431,11 +433,11 @@
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + (skill_dmg_list)) * pow! * constant",
-                "value": "((1 * hero_atk)) * (1 + (skill_dmg_list[2.5, 2, 0])) * 1 * 1.871",
-                "simplified": "((1.871 * hero_atk)) * (1 + (skill_dmg_list[2.5, 2, 0]))",
-                "soulburn": "((1 * hero_atk)) * (1 + (skill_dmg_list[2.5, 2, 0])) * 1 * 1.871",
-                "simplifiedSoulburn": "((1.871 * hero_atk)) * (1 + (skill_dmg_list[2.5, 2, 0]))"
+                "description": "((atk_rate * hero_atk)) * (1 + (targets_rate)) * pow! * constant",
+                "value": "((1 * hero_atk)) * (1 + ((targets_rate[0, 2.5, 2, 0]))) * 1 * 1.871",
+                "simplified": "((1.871 * hero_atk)) * (1 + ((targets_rate[0, 2.5, 2, 0])))",
+                "soulburn": "((1 * hero_atk)) * (1 + ((targets_rate[0, 2.5, 2, 0]))) * 1 * 1.871",
+                "simplifiedSoulburn": "((1.871 * hero_atk)) * (1 + ((targets_rate[0, 2.5, 2, 0])))"
             }
         }
     ],

--- a/src/hero/hazel.json
+++ b/src/hero/hazel.json
@@ -183,9 +183,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.05 * 1.871",
+                "value": "((1 * hero_atk)) * 1.05 * 1.871",
                 "simplified": "((1.9646 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.05 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1.05 * 1.871",
                 "simplifiedSoulburn": "((1.9646 * hero_atk))"
             }
         },

--- a/src/hero/helga.json
+++ b/src/hero/helga.json
@@ -226,9 +226,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },

--- a/src/hero/hurado.json
+++ b/src/hero/hurado.json
@@ -209,9 +209,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 0.9 * 1.871",
+                "value": "((1 * hero_atk)) * 0.9 * 1.871",
                 "simplified": "((1.6839 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 0.9 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 0.9 * 1.871",
                 "simplifiedSoulburn": "((1.6839 * hero_atk))"
             }
         },
@@ -422,9 +422,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.9 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.9 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.6839 * hero_atk))",
-                "soulburn": "((0.9 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((0.9 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.6839 * hero_atk))"
             }
         }

--- a/src/hero/iseria.json
+++ b/src/hero/iseria.json
@@ -238,9 +238,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 0.95 * 1.871",
+                "value": "((1 * hero_atk)) * 0.95 * 1.871",
                 "simplified": "((1.7774 * hero_atk))",
-                "soulburn": "((2.0 * hero_atk)) * 0.95 * 1.871",
+                "soulburn": "((2 * hero_atk)) * 0.95 * 1.871",
                 "simplifiedSoulburn": "((3.5549 * hero_atk))"
             }
         },
@@ -437,9 +437,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((2.0 * hero_atk)) * 0.9 * 1.871",
+                "value": "((2 * hero_atk)) * 0.9 * 1.871",
                 "simplified": "((3.3678 * hero_atk))",
-                "soulburn": "((2.0 * hero_atk)) * 0.9 * 1.871",
+                "soulburn": "((2 * hero_atk)) * 0.9 * 1.871",
                 "simplifiedSoulburn": "((3.3678 * hero_atk))"
             }
         }

--- a/src/hero/jecht.json
+++ b/src/hero/jecht.json
@@ -179,9 +179,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.05 * 1.871",
+                "value": "((1 * hero_atk)) * 1.05 * 1.871",
                 "simplified": "((1.9646 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.05 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1.05 * 1.871",
                 "simplifiedSoulburn": "((1.9646 * hero_atk))"
             }
         },

--- a/src/hero/jena.json
+++ b/src/hero/jena.json
@@ -187,9 +187,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * (1 + ((0.1 * hero_special_count))) * 0.95 * 1.871",
+                "value": "((1 * hero_atk)) * (1 + ((0.1 * hero_special_count))) * 0.95 * 1.871",
                 "simplified": "((1.7774 * hero_atk)) * (1 + ((0.1 * hero_special_count)))",
-                "soulburn": "((1.0 * hero_atk)) * (1 + ((0.1 * hero_special_count))) * 0.95 * 1.871",
+                "soulburn": "((1 * hero_atk)) * (1 + ((0.1 * hero_special_count))) * 0.95 * 1.871",
                 "simplifiedSoulburn": "((1.7774 * hero_atk)) * (1 + ((0.1 * hero_special_count)))"
             }
         },

--- a/src/hero/jena.json
+++ b/src/hero/jena.json
@@ -186,11 +186,11 @@
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((target_debuff_rate * target_num_debuffs))) * pow! * constant",
-                "value": "((1 * hero_atk)) * (1 + ((0.1 * target_num_debuffs))) * 0.95 * 1.871",
-                "simplified": "((1.7774 * hero_atk)) * (1 + ((0.1 * target_num_debuffs)))",
-                "soulburn": "((1 * hero_atk)) * (1 + ((0.1 * target_num_debuffs))) * 0.95 * 1.871",
-                "simplifiedSoulburn": "((1.7774 * hero_atk)) * (1 + ((0.1 * target_num_debuffs)))"
+                "description": "((atk_rate * hero_atk)) * (1 + ((target_debuff_rate * target_debuffs))) * pow! * constant",
+                "value": "((1 * hero_atk)) * (1 + ((0.1 * target_debuffs))) * 0.95 * 1.871",
+                "simplified": "((1.7774 * hero_atk)) * (1 + ((0.1 * target_debuffs)))",
+                "soulburn": "((1 * hero_atk)) * (1 + ((0.1 * target_debuffs))) * 0.95 * 1.871",
+                "simplifiedSoulburn": "((1.7774 * hero_atk)) * (1 + ((0.1 * target_debuffs)))"
             }
         },
         {

--- a/src/hero/jena.json
+++ b/src/hero/jena.json
@@ -179,18 +179,18 @@
                     "soulburn": 1
                 },
                 {
-                    "name": "skill_dmg_rate",
+                    "name": "target_debuff_rate",
                     "description": "Increased damage per debuff on target.",
                     "value": 0.1,
                     "soulburn": 0.1
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((1 * hero_atk)) * (1 + ((0.1 * hero_special_count))) * 0.95 * 1.871",
-                "simplified": "((1.7774 * hero_atk)) * (1 + ((0.1 * hero_special_count)))",
-                "soulburn": "((1 * hero_atk)) * (1 + ((0.1 * hero_special_count))) * 0.95 * 1.871",
-                "simplifiedSoulburn": "((1.7774 * hero_atk)) * (1 + ((0.1 * hero_special_count)))"
+                "description": "((atk_rate * hero_atk)) * (1 + ((target_debuff_rate * target_num_debuffs))) * pow! * constant",
+                "value": "((1 * hero_atk)) * (1 + ((0.1 * target_num_debuffs))) * 0.95 * 1.871",
+                "simplified": "((1.7774 * hero_atk)) * (1 + ((0.1 * target_num_debuffs)))",
+                "soulburn": "((1 * hero_atk)) * (1 + ((0.1 * target_num_debuffs))) * 0.95 * 1.871",
+                "simplifiedSoulburn": "((1.7774 * hero_atk)) * (1 + ((0.1 * target_num_debuffs)))"
             }
         },
         {

--- a/src/hero/judge-kise.json
+++ b/src/hero/judge-kise.json
@@ -191,9 +191,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -295,9 +295,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * (1 + ((0.1 * hero_special_count))) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * (1 + ((0.1 * hero_special_count))) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk)) * (1 + ((0.1 * hero_special_count)))",
-                "soulburn": "((1.0 * hero_atk)) * (1 + ((0.1 * hero_special_count))) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * (1 + ((0.1 * hero_special_count))) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk)) * (1 + ((0.1 * hero_special_count)))"
             }
         },
@@ -436,9 +436,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 0.9 * 1.871",
+                "value": "((1 * hero_atk)) * 0.9 * 1.871",
                 "simplified": "((1.6839 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 0.9 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 0.9 * 1.871",
                 "simplifiedSoulburn": "((1.6839 * hero_atk))"
             }
         }

--- a/src/hero/judge-kise.json
+++ b/src/hero/judge-kise.json
@@ -287,18 +287,28 @@
                     "soulburn": 1
                 },
                 {
-                    "name": "skill_dmg_rate",
+                    "name": "targets_rate",
                     "description": "Increases damage per extra target.",
-                    "value": 0.1,
-                    "soulburn": 0.1
+                    "value": [
+                        0,
+                        0.1,
+                        0.2,
+                        0.3
+                    ],
+                    "soulburn": [
+                        0,
+                        0.1,
+                        0.2,
+                        0.3
+                    ]
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((1 * hero_atk)) * (1 + ((0.1 * hero_special_count))) * 1 * 1.871",
-                "simplified": "((1.871 * hero_atk)) * (1 + ((0.1 * hero_special_count)))",
-                "soulburn": "((1 * hero_atk)) * (1 + ((0.1 * hero_special_count))) * 1 * 1.871",
-                "simplifiedSoulburn": "((1.871 * hero_atk)) * (1 + ((0.1 * hero_special_count)))"
+                "description": "((atk_rate * hero_atk)) * (1 + (targets_rate)) * pow! * constant",
+                "value": "((1 * hero_atk)) * (1 + ((targets_rate[0, 0.1, 0.2, 0.3]))) * 1 * 1.871",
+                "simplified": "((1.871 * hero_atk)) * (1 + ((targets_rate[0, 0.1, 0.2, 0.3])))",
+                "soulburn": "((1 * hero_atk)) * (1 + ((targets_rate[0, 0.1, 0.2, 0.3]))) * 1 * 1.871",
+                "simplifiedSoulburn": "((1.871 * hero_atk)) * (1 + ((targets_rate[0, 0.1, 0.2, 0.3])))"
             }
         },
         {

--- a/src/hero/judith.json
+++ b/src/hero/judith.json
@@ -192,9 +192,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },

--- a/src/hero/karin.json
+++ b/src/hero/karin.json
@@ -193,9 +193,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 0.95 * 1.871",
+                "value": "((1 * hero_atk)) * 0.95 * 1.871",
                 "simplified": "((1.7774 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 0.95 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 0.95 * 1.871",
                 "simplifiedSoulburn": "((1.7774 * hero_atk))"
             }
         },
@@ -293,9 +293,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 0.9 * 1.871",
+                "value": "((1 * hero_atk)) * 0.9 * 1.871",
                 "simplified": "((1.6839 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 0.9 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 0.9 * 1.871",
                 "simplifiedSoulburn": "((1.6839 * hero_atk))"
             }
         },

--- a/src/hero/kayron.json
+++ b/src/hero/kayron.json
@@ -222,9 +222,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((self_hp_current_rate * hero_hp_remaining_percent))) * pow! * constant",
-                "value": "((0.85 * hero_atk)) * (1 + ((0.0015 * hero_hp_remaining_percent))) * 1.0 * 1.871",
+                "value": "((0.85 * hero_atk)) * (1 + ((0.0015 * hero_hp_remaining_percent))) * 1 * 1.871",
                 "simplified": "((1.5903 * hero_atk)) * (1 + ((0.0015 * hero_hp_remaining_percent)))",
-                "soulburn": "((1.35 * hero_atk)) * (1 + ((0.0015 * hero_hp_remaining_percent))) * 1.0 * 1.871",
+                "soulburn": "((1.35 * hero_atk)) * (1 + ((0.0015 * hero_hp_remaining_percent))) * 1 * 1.871",
                 "simplifiedSoulburn": "((2.5259 * hero_atk)) * (1 + ((0.0015 * hero_hp_remaining_percent)))"
             }
         },

--- a/src/hero/ken.json
+++ b/src/hero/ken.json
@@ -211,9 +211,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (hp_rate * hero_hp)) * pow! * constant",
-                "value": "((1.0 * hero_atk) + (0.1 * hero_hp)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk) + (0.1 * hero_hp)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk) + (0.1871 * hero_hp))",
-                "soulburn": "((1.0 * hero_atk) + (0.1 * hero_hp)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk) + (0.1 * hero_hp)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk) + (0.1871 * hero_hp))"
             }
         },
@@ -306,9 +306,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (hp_rate * hero_hp)) * pow! * constant",
-                "value": "((1.2 * hero_atk) + (0.1 * hero_hp)) * 1.0 * 1.871",
+                "value": "((1.2 * hero_atk) + (0.1 * hero_hp)) * 1 * 1.871",
                 "simplified": "((2.2452 * hero_atk) + (0.1871 * hero_hp))",
-                "soulburn": "((1.2 * hero_atk) + (0.1 * hero_hp)) * 1.0 * 1.871",
+                "soulburn": "((1.2 * hero_atk) + (0.1 * hero_hp)) * 1 * 1.871",
                 "simplifiedSoulburn": "((2.2452 * hero_atk) + (0.1871 * hero_hp))"
             }
         },

--- a/src/hero/khawazu.json
+++ b/src/hero/khawazu.json
@@ -225,9 +225,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 0.95 * 1.871",
+                "value": "((1 * hero_atk)) * 0.95 * 1.871",
                 "simplified": "((1.7774 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 0.95 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 0.95 * 1.871",
                 "simplifiedSoulburn": "((1.7774 * hero_atk))"
             }
         },
@@ -421,9 +421,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         }

--- a/src/hero/kikirat-v2.json
+++ b/src/hero/kikirat-v2.json
@@ -187,9 +187,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (def_rate * hero_def)) * pow! * constant",
-                "value": "((0.5 * hero_atk) + (0.7 * hero_def)) * 1.0 * 1.871",
+                "value": "((0.5 * hero_atk) + (0.7 * hero_def)) * 1 * 1.871",
                 "simplified": "((0.9355 * hero_atk) + (1.3097 * hero_def))",
-                "soulburn": "((0.5 * hero_atk) + (0.7 * hero_def)) * 1.0 * 1.871",
+                "soulburn": "((0.5 * hero_atk) + (0.7 * hero_def)) * 1 * 1.871",
                 "simplifiedSoulburn": "((0.9355 * hero_atk) + (1.3097 * hero_def))"
             }
         },
@@ -418,9 +418,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (def_rate * hero_def)) * pow! * constant",
-                "value": "((0.4 * hero_atk) + (0.5 * hero_def)) * 1.0 * 1.871",
+                "value": "((0.4 * hero_atk) + (0.5 * hero_def)) * 1 * 1.871",
                 "simplified": "((0.7484 * hero_atk) + (0.9355 * hero_def))",
-                "soulburn": "((0.5 * hero_atk) + (0.6 * hero_def)) * 1.0 * 1.871",
+                "soulburn": "((0.5 * hero_atk) + (0.6 * hero_def)) * 1 * 1.871",
                 "simplifiedSoulburn": "((0.9355 * hero_atk) + (1.1226 * hero_def))"
             }
         }

--- a/src/hero/kiris.json
+++ b/src/hero/kiris.json
@@ -222,9 +222,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 0.9 * 1.871",
+                "value": "((1 * hero_atk)) * 0.9 * 1.871",
                 "simplified": "((1.6839 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 0.9 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 0.9 * 1.871",
                 "simplifiedSoulburn": "((1.6839 * hero_atk))"
             }
         },
@@ -350,9 +350,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.7 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.7 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.3097 * hero_atk))",
-                "soulburn": "((0.7 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((0.7 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.3097 * hero_atk))"
             }
         },

--- a/src/hero/kise.json
+++ b/src/hero/kise.json
@@ -194,9 +194,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.1 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1.1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((2.0581 * hero_atk))",
-                "soulburn": "((1.4 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1.4 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((2.6194 * hero_atk))"
             }
         },
@@ -305,9 +305,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.8 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.8 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.4968 * hero_atk))",
-                "soulburn": "((0.8 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((0.8 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.4968 * hero_atk))"
             }
         },
@@ -423,9 +423,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((self_hp_current_rate * hero_hp_remaining_percent))) * pow! * constant",
-                "value": "((1.6 * hero_atk)) * (1 + ((0.0035 * hero_hp_remaining_percent))) * 1.0 * 1.871",
+                "value": "((1.6 * hero_atk)) * (1 + ((0.0035 * hero_hp_remaining_percent))) * 1 * 1.871",
                 "simplified": "((2.9936 * hero_atk)) * (1 + ((0.0035 * hero_hp_remaining_percent)))",
-                "soulburn": "((1.6 * hero_atk)) * (1 + ((0.0035 * hero_hp_remaining_percent))) * 1.0 * 1.871",
+                "soulburn": "((1.6 * hero_atk)) * (1 + ((0.0035 * hero_hp_remaining_percent))) * 1 * 1.871",
                 "simplifiedSoulburn": "((2.9936 * hero_atk)) * (1 + ((0.0035 * hero_hp_remaining_percent)))"
             }
         }

--- a/src/hero/kluri.json
+++ b/src/hero/kluri.json
@@ -431,7 +431,7 @@
                 }
             ],
             "simpleDmgMod": {
-                "description": " * pow! * constant",
+                "description": "",
                 "value": "",
                 "simplified": "",
                 "soulburn": "",

--- a/src/hero/krau.json
+++ b/src/hero/krau.json
@@ -222,9 +222,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (hp_rate * hero_hp)) * pow! * constant",
-                "value": "((0.7 * hero_atk) + (0.085 * hero_hp)) * 1.0 * 1.871",
+                "value": "((0.7 * hero_atk) + (0.085 * hero_hp)) * 1 * 1.871",
                 "simplified": "((1.3097 * hero_atk) + (0.159 * hero_hp))",
-                "soulburn": "((0.7 * hero_atk) + (0.085 * hero_hp)) * 1.0 * 1.871",
+                "soulburn": "((0.7 * hero_atk) + (0.085 * hero_hp)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.3097 * hero_atk) + (0.159 * hero_hp))"
             }
         },
@@ -370,9 +370,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (hp_rate * hero_hp)) * pow! * constant",
-                "value": "((0.8 * hero_atk) + (0.13 * hero_hp)) * 1.0 * 1.871",
+                "value": "((0.8 * hero_atk) + (0.13 * hero_hp)) * 1 * 1.871",
                 "simplified": "((1.4968 * hero_atk) + (0.2432 * hero_hp))",
-                "soulburn": "((0.8 * hero_atk) + (0.13 * hero_hp)) * 1.0 * 1.871",
+                "soulburn": "((0.8 * hero_atk) + (0.13 * hero_hp)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.4968 * hero_atk) + (0.2432 * hero_hp))"
             }
         },
@@ -445,9 +445,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.3 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.3 * hero_atk)) * 1 * 1.871",
                 "simplified": "((0.5613 * hero_atk))",
-                "soulburn": "((0.3 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((0.3 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((0.5613 * hero_atk))"
             }
         }

--- a/src/hero/leo.json
+++ b/src/hero/leo.json
@@ -196,9 +196,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.9 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.9 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.6839 * hero_atk))",
-                "soulburn": "((0.9 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((0.9 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.6839 * hero_atk))"
             }
         },

--- a/src/hero/lidica.json
+++ b/src/hero/lidica.json
@@ -202,9 +202,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -315,9 +315,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.7 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.7 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.3097 * hero_atk))",
-                "soulburn": "((0.7 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((0.7 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.3097 * hero_atk))"
             }
         },
@@ -431,9 +431,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.6 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1.6 * hero_atk)) * 1 * 1.871",
                 "simplified": "((2.9936 * hero_atk))",
-                "soulburn": "((1.6 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1.6 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((2.9936 * hero_atk))"
             }
         }

--- a/src/hero/lilias.json
+++ b/src/hero/lilias.json
@@ -218,9 +218,9 @@
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (hp_rate * hero_hp)) * pow! * constant",
                 "value": "((0.8 * hero_atk) + (0.12 * hero_hp)) * 0.95 * 1.871",
-                "simplified": "((1.422 * hero_atk) + (0.213 * hero_hp))",
+                "simplified": "((1.422 * hero_atk) + (0.2133 * hero_hp))",
                 "soulburn": "((0.8 * hero_atk) + (0.12 * hero_hp)) * 0.95 * 1.871",
-                "simplifiedSoulburn": "((1.422 * hero_atk) + (0.213 * hero_hp))"
+                "simplifiedSoulburn": "((1.422 * hero_atk) + (0.2133 * hero_hp))"
             }
         },
         {
@@ -440,9 +440,9 @@
             "simpleDmgMod": {
                 "description": "((ally_atk_rate * ally_atk)) * pow! * constant",
                 "value": "((0.9 * ally_atk)) * 1 * 1.871",
-                "simplified": "((1.684 * ally_atk))",
+                "simplified": "((1.6839 * ally_atk))",
                 "soulburn": "((0.9 * ally_atk)) * 1 * 1.871",
-                "simplifiedSoulburn": "((1.684 * ally_atk))"
+                "simplifiedSoulburn": "((1.6839 * ally_atk))"
             }
         }
     ],

--- a/src/hero/lilibet.json
+++ b/src/hero/lilibet.json
@@ -192,9 +192,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -311,10 +311,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((1.5 * hero_atk)) * (1 + ((0.2 * hero_special_count))) * 1.0 * 1.871",
-                "simplified": "((2.807 * hero_atk)) * (1 + ((0.2 * hero_special_count)))",
-                "soulburn": "((1.5 * hero_atk)) * (1 + ((0.2 * hero_special_count))) * 1.0 * 1.871",
-                "simplifiedSoulburn": "((2.807 * hero_atk)) * (1 + ((0.2 * hero_special_count)))"
+                "value": "((1.5 * hero_atk)) * (1 + ((0.2 * hero_special_count))) * 1 * 1.871",
+                "simplified": "((2.8065 * hero_atk)) * (1 + ((0.2 * hero_special_count)))",
+                "soulburn": "((1.5 * hero_atk)) * (1 + ((0.2 * hero_special_count))) * 1 * 1.871",
+                "simplifiedSoulburn": "((2.8065 * hero_atk)) * (1 + ((0.2 * hero_special_count)))"
             }
         },
         {
@@ -425,9 +425,9 @@
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
                 "value": "((2.0 * hero_atk)) * 0.95 * 1.871",
-                "simplified": "((3.586 * hero_atk))",
+                "simplified": "((3.5549 * hero_atk))",
                 "soulburn": "((2.6 * hero_atk)) * 0.95 * 1.871",
-                "simplifiedSoulburn": "((4.621 * hero_atk))"
+                "simplifiedSoulburn": "((4.6214 * hero_atk))"
             }
         }
     ],

--- a/src/hero/lorina.json
+++ b/src/hero/lorina.json
@@ -194,9 +194,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 0.9 * 1.871",
+                "value": "((1 * hero_atk)) * 0.9 * 1.871",
                 "simplified": "((1.6839 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 0.9 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 0.9 * 1.871",
                 "simplifiedSoulburn": "((1.6839 * hero_atk))"
             }
         },

--- a/src/hero/lots.json
+++ b/src/hero/lots.json
@@ -200,9 +200,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },

--- a/src/hero/ludwig.json
+++ b/src/hero/ludwig.json
@@ -198,9 +198,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },

--- a/src/hero/luluca.json
+++ b/src/hero/luluca.json
@@ -209,11 +209,11 @@
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count) * (target_hp_missing_rate * target_hp_lost_percent))) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * (1 + ((0.2 * hero_special_count) * (0.2 * target_hp_lost_percent))) * 1.0 * 1.871",
-                "simplified": "((1.871 * hero_atk)) * (1 + ((0.2 * hero_special_count) * (0.2 * target_hp_lost_percent)))",
-                "soulburn": "((1.0 * hero_atk)) * (1 + ((0.2 * hero_special_count) * (0.2 * target_hp_lost_percent))) * 1.0 * 1.871",
-                "simplifiedSoulburn": "((1.871 * hero_atk)) * (1 + ((0.2 * hero_special_count) * (0.2 * target_hp_lost_percent)))"
+                "description": "((atk_rate * hero_atk)) * (1 + ((target_hp_missing_rate * target_hp_lost_percent) + (skill_dmg_rate * hero_special_count))) * pow! * constant",
+                "value": "((1 * hero_atk)) * (1 + ((0.2 * target_hp_lost_percent) + (0.2 * hero_special_count))) * 1 * 1.871",
+                "simplified": "((1.871 * hero_atk)) * (1 + ((0.2 * target_hp_lost_percent) + (0.2 * hero_special_count)))",
+                "soulburn": "((1 * hero_atk)) * (1 + ((0.2 * target_hp_lost_percent) + (0.2 * hero_special_count))) * 1 * 1.871",
+                "simplifiedSoulburn": "((1.871 * hero_atk)) * (1 + ((0.2 * target_hp_lost_percent) + (0.2 * hero_special_count)))"
             }
         },
         {
@@ -328,11 +328,11 @@
                 }
             ],
             "simpleDmgMod": {
-                "description": "",
-                "value": "",
-                "simplified": "",
-                "soulburn": "",
-                "simplifiedSoulburn": ""
+                "description": "(1 + ((skill_dmg_rate * hero_special_count))) * constant",
+                "value": "(1 + ((0.2 * hero_special_count))) * 1.871",
+                "simplified": "(1 + ((0.2 * hero_special_count)))",
+                "soulburn": "(1 + ((0.2 * hero_special_count))) * 1.871",
+                "simplifiedSoulburn": "(1 + ((0.2 * hero_special_count)))"
             }
         },
         {

--- a/src/hero/luna.json
+++ b/src/hero/luna.json
@@ -205,10 +205,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "(([0.7, 1, 4, 2.1] * hero_atk)) * 0.95 * 1.871",
-                "simplified": "(([1.2442, 1.7774, 7.1098, 3.7326] * hero_atk))",
-                "soulburn": "(([0.7, 1, 4, 2.1] * hero_atk)) * 0.95 * 1.871",
-                "simplifiedSoulburn": "(([1.2442, 1.7774, 7.1098, 3.7326] * hero_atk))"
+                "value": "((atk_rate[0.7, 1, 4, 2.1] * hero_atk)) * 0.95 * 1.871",
+                "simplified": "((atk_rate[1.2442, 1.7774, 7.1098, 3.7326] * hero_atk))",
+                "soulburn": "((atk_rate[0.7, 1, 4, 2.1] * hero_atk)) * 0.95 * 1.871",
+                "simplifiedSoulburn": "((atk_rate[1.2442, 1.7774, 7.1098, 3.7326] * hero_atk))"
             }
         },
         {

--- a/src/hero/maid-chloe.json
+++ b/src/hero/maid-chloe.json
@@ -226,9 +226,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },

--- a/src/hero/martial-artist-ken.json
+++ b/src/hero/martial-artist-ken.json
@@ -200,9 +200,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 0.95 * 1.871",
+                "value": "((1 * hero_atk)) * 0.95 * 1.871",
                 "simplified": "((1.7774 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 0.95 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 0.95 * 1.871",
                 "simplifiedSoulburn": "((1.7774 * hero_atk))"
             }
         },
@@ -420,9 +420,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.9 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.9 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.6839 * hero_atk))",
-                "soulburn": "((1.1 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1.1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((2.0581 * hero_atk))"
             }
         }

--- a/src/hero/mascot-hazel.json
+++ b/src/hero/mascot-hazel.json
@@ -187,9 +187,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.05 * 1.871",
+                "value": "((1 * hero_atk)) * 1.05 * 1.871",
                 "simplified": "((1.9646 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.05 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1.05 * 1.871",
                 "simplifiedSoulburn": "((1.9646 * hero_atk))"
             }
         },

--- a/src/hero/maya.json
+++ b/src/hero/maya.json
@@ -353,9 +353,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (def_rate * hero_def)) * pow! * constant",
-                "value": "((0.8 * hero_atk) + (0.8 * hero_def)) * 1.0 * 1.871",
+                "value": "((0.8 * hero_atk) + (0.8 * hero_def)) * 1 * 1.871",
                 "simplified": "((1.4968 * hero_atk) + (1.4968 * hero_def))",
-                "soulburn": "((0.8 * hero_atk) + (0.8 * hero_def)) * 1.0 * 1.871",
+                "soulburn": "((0.8 * hero_atk) + (0.8 * hero_def)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.4968 * hero_atk) + (1.4968 * hero_def))"
             }
         },

--- a/src/hero/mirsa.json
+++ b/src/hero/mirsa.json
@@ -218,9 +218,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((spd_rate * hero_spd))) * pow! * constant",
-                "value": "((0.9 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1.0 * 1.871",
+                "value": "((0.9 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1 * 1.871",
                 "simplified": "((1.6839 * hero_atk)) * (1 + ((0.00075 * hero_spd)))",
-                "soulburn": "((0.9 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1.0 * 1.871",
+                "soulburn": "((0.9 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.6839 * hero_atk)) * (1 + ((0.00075 * hero_spd)))"
             }
         },

--- a/src/hero/mistychain.json
+++ b/src/hero/mistychain.json
@@ -186,9 +186,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -413,9 +413,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.5 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1.5 * hero_atk)) * 1 * 1.871",
                 "simplified": "((2.8065 * hero_atk))",
-                "soulburn": "((2.2 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((2.2 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((4.1162 * hero_atk))"
             }
         }

--- a/src/hero/montmorancy.json
+++ b/src/hero/montmorancy.json
@@ -196,9 +196,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },

--- a/src/hero/mucacha.json
+++ b/src/hero/mucacha.json
@@ -199,9 +199,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((spd_rate * hero_spd))) * pow! * constant",
-                "value": "((0.9 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1.0 * 1.871",
+                "value": "((0.9 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1 * 1.871",
                 "simplified": "((1.6839 * hero_atk)) * (1 + ((0.00075 * hero_spd)))",
-                "soulburn": "((0.9 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1.0 * 1.871",
+                "soulburn": "((0.9 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.6839 * hero_atk)) * (1 + ((0.00075 * hero_spd)))"
             }
         },
@@ -430,9 +430,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((spd_rate * hero_spd))) * pow! * constant",
-                "value": "((1.5 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1.0 * 1.871",
+                "value": "((1.5 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1 * 1.871",
                 "simplified": "((2.8065 * hero_atk)) * (1 + ((0.00075 * hero_spd)))",
-                "soulburn": "((1.5 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1.0 * 1.871",
+                "soulburn": "((1.5 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1 * 1.871",
                 "simplifiedSoulburn": "((2.8065 * hero_atk)) * (1 + ((0.00075 * hero_spd)))"
             }
         }

--- a/src/hero/nemunas.json
+++ b/src/hero/nemunas.json
@@ -211,9 +211,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 0.95 * 1.871",
+                "value": "((1 * hero_atk)) * 0.95 * 1.871",
                 "simplified": "((1.7774 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 0.95 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 0.95 * 1.871",
                 "simplifiedSoulburn": "((1.7774 * hero_atk))"
             }
         },
@@ -359,7 +359,7 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (hp_rate * hero_hp)) * pow! * constant",
-                "value": "((1.0 * hero_atk) + (0.05 * hero_hp)) * 0.8 * 1.871",
+                "value": "((1 * hero_atk) + (0.05 * hero_hp)) * 0.8 * 1.871",
                 "simplified": "((1.4968 * hero_atk) + (0.0748 * hero_hp))",
                 "soulburn": "((1.7 * hero_atk) + (0.085 * hero_hp)) * 0.8 * 1.871",
                 "simplifiedSoulburn": "((2.5446 * hero_atk) + (0.1272 * hero_hp))"

--- a/src/hero/otillie.json
+++ b/src/hero/otillie.json
@@ -196,9 +196,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -419,9 +419,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.8 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1.8 * hero_atk)) * 1 * 1.871",
                 "simplified": "((3.3678 * hero_atk))",
-                "soulburn": "((1.8 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1.8 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((3.3678 * hero_atk))"
             }
         }

--- a/src/hero/pearlhorizon.json
+++ b/src/hero/pearlhorizon.json
@@ -205,9 +205,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -292,9 +292,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.6 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.6 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.1226 * hero_atk))",
-                "soulburn": "((0.6 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((0.6 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.1226 * hero_atk))"
             }
         },
@@ -434,10 +434,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (target_hp_rate * target_hp)) * pow! * constant",
-                "value": "((1.5 * hero_atk) + ([0.0, 0.2] * target_hp)) * 0.9 * 1.871",
-                "simplified": "((2.5259 * hero_atk) + ([0.0, 0.3368] * target_hp))",
-                "soulburn": "((2.2 * hero_atk) + ([0.0, 0.2] * target_hp)) * 0.9 * 1.871",
-                "simplifiedSoulburn": "((3.7046 * hero_atk) + ([0.0, 0.3368] * target_hp))"
+                "value": "((1.5 * hero_atk) + (target_hp_rate[0, 0.2] * target_hp)) * 0.9 * 1.871",
+                "simplified": "((2.5259 * hero_atk) + (target_hp_rate[0.0, 0.3368] * target_hp))",
+                "soulburn": "((2.2 * hero_atk) + (target_hp_rate[0, 0.2] * target_hp)) * 0.9 * 1.871",
+                "simplifiedSoulburn": "((3.7046 * hero_atk) + (target_hp_rate[0.0, 0.3368] * target_hp))"
             }
         }
     ],

--- a/src/hero/purrgis.json
+++ b/src/hero/purrgis.json
@@ -204,11 +204,11 @@
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk) + (0.05 * hero_hp)) * 1.0 * 1.871",
-                "simplified": "((1.871 * hero_atk) + (0.094 * hero_hp))",
-                "soulburn": "((1.0 * hero_atk) + (0.05 * hero_hp)) * 1.0 * 1.871",
-                "simplifiedSoulburn": "((1.871 * hero_atk) + (0.094 * hero_hp))"
+                "description": "((atk_rate * hero_atk) + (hp_rate * hero_hp)) * pow! * constant",
+                "value": "((1 * hero_atk) + (0.05 * hero_hp)) * 1 * 1.871",
+                "simplified": "((1.871 * hero_atk) + (0.0936 * hero_hp))",
+                "soulburn": "((1 * hero_atk) + (0.05 * hero_hp)) * 1 * 1.871",
+                "simplifiedSoulburn": "((1.871 * hero_atk) + (0.0936 * hero_hp))"
             }
         },
         {
@@ -435,11 +435,11 @@
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.8 * hero_atk) + (0.1 * hero_hp)) * 1.0 * 1.871",
-                "simplified": "((1.4968 * hero_atk) + (0.188 * hero_hp))",
-                "soulburn": "((1.05 * hero_atk) + (0.1 * hero_hp)) * 1.0 * 1.871",
-                "simplifiedSoulburn": "((1.9646 * hero_atk) + (0.188 * hero_hp))"
+                "description": "((atk_rate * hero_atk) + (hp_rate * hero_hp)) * pow! * constant",
+                "value": "((0.8 * hero_atk) + (0.1 * hero_hp)) * 1 * 1.871",
+                "simplified": "((1.4968 * hero_atk) + (0.1871 * hero_hp))",
+                "soulburn": "((1.05 * hero_atk) + (0.1 * hero_hp)) * 1 * 1.871",
+                "simplifiedSoulburn": "((1.9646 * hero_atk) + (0.1871 * hero_hp))"
             }
         }
     ],

--- a/src/hero/pyllis.json
+++ b/src/hero/pyllis.json
@@ -201,9 +201,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (def_rate * hero_def)) * pow! * constant",
-                "value": "((0.7 * hero_atk) + (0.4 * hero_def)) * 1.0 * 1.871",
+                "value": "((0.7 * hero_atk) + (0.4 * hero_def)) * 1 * 1.871",
                 "simplified": "((1.3097 * hero_atk) + (0.7484 * hero_def))",
-                "soulburn": "((0.7 * hero_atk) + (0.4 * hero_def)) * 1.0 * 1.871",
+                "soulburn": "((0.7 * hero_atk) + (0.4 * hero_def)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.3097 * hero_atk) + (0.7484 * hero_def))"
             }
         },

--- a/src/hero/ras.json
+++ b/src/hero/ras.json
@@ -215,9 +215,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (hp_rate * hero_hp)) * pow! * constant",
-                "value": "((0.9 * hero_atk) + (0.04 * hero_hp)) * 1.0 * 1.871",
+                "value": "((0.9 * hero_atk) + (0.04 * hero_hp)) * 1 * 1.871",
                 "simplified": "((1.6839 * hero_atk) + (0.0748 * hero_hp))",
-                "soulburn": "((0.9 * hero_atk) + (0.04 * hero_hp)) * 1.0 * 1.871",
+                "soulburn": "((0.9 * hero_atk) + (0.04 * hero_hp)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.6839 * hero_atk) + (0.0748 * hero_hp))"
             }
         },
@@ -326,9 +326,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.5 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1.5 * hero_atk)) * 1 * 1.871",
                 "simplified": "((2.8065 * hero_atk))",
-                "soulburn": "((1.5 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1.5 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((2.8065 * hero_atk))"
             }
         },
@@ -444,9 +444,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (hp_rate * hero_hp)) * pow! * constant",
-                "value": "((0.9 * hero_atk) + (0.04 * hero_hp)) * 1.0 * 1.871",
+                "value": "((0.9 * hero_atk) + (0.04 * hero_hp)) * 1 * 1.871",
                 "simplified": "((1.6839 * hero_atk) + (0.0748 * hero_hp))",
-                "soulburn": "((0.9 * hero_atk) + (0.04 * hero_hp)) * 1.0 * 1.871",
+                "soulburn": "((0.9 * hero_atk) + (0.04 * hero_hp)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.6839 * hero_atk) + (0.0748 * hero_hp))"
             }
         }

--- a/src/hero/ravi.json
+++ b/src/hero/ravi.json
@@ -197,10 +197,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "(([1.0, 1.15, 1.3, 1.45, 1.6, 1.75] * hero_atk)) * 1.0 * 1.871",
-                "simplified": "(([1.871, 2.1516, 2.4323, 2.7129, 2.9936, 3.2742] * hero_atk))",
-                "soulburn": "(([2.5, 2.65, 2.8, 2.95, 3.1, 3.25] * hero_atk)) * 1.0 * 1.871",
-                "simplifiedSoulburn": "(([4.6775, 4.9581, 5.2388, 5.5194, 5.8001, 6.0808] * hero_atk))"
+                "value": "((atk_rate[1, 1.15, 1.3, 1.45, 1.6, 1.75] * hero_atk)) * 1 * 1.871",
+                "simplified": "((atk_rate[1.871, 2.1516, 2.4323, 2.7129, 2.9936, 3.2742] * hero_atk))",
+                "soulburn": "((atk_rate[2.5, 2.65, 2.8, 2.95, 3.1, 3.25] * hero_atk)) * 1 * 1.871",
+                "simplifiedSoulburn": "((atk_rate[4.6775, 4.9581, 5.2388, 5.5194, 5.8001, 6.0808] * hero_atk))"
             }
         },
         {
@@ -436,10 +436,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "(([1.2, 1.35, 1.5, 1.65, 1.8, 1.95] * hero_atk)) * 0.95 * 1.871",
-                "simplified": "(([2.1329, 2.3996, 2.6662, 2.9328, 3.1994, 3.466] * hero_atk))",
-                "soulburn": "(([1.2, 1.35, 1.5, 1.65, 1.8, 1.95] * hero_atk)) * 0.95 * 1.871",
-                "simplifiedSoulburn": "(([2.1329, 2.3996, 2.6662, 2.9328, 3.1994, 3.466] * hero_atk))"
+                "value": "((atk_rate[1.2, 1.35, 1.5, 1.65, 1.8, 1.95] * hero_atk)) * 0.95 * 1.871",
+                "simplified": "((atk_rate[2.1329, 2.3996, 2.6662, 2.9328, 3.1994, 3.466] * hero_atk))",
+                "soulburn": "((atk_rate[1.2, 1.35, 1.5, 1.65, 1.8, 1.95] * hero_atk)) * 0.95 * 1.871",
+                "simplifiedSoulburn": "((atk_rate[2.1329, 2.3996, 2.6662, 2.9328, 3.1994, 3.466] * hero_atk))"
             }
         }
     ],

--- a/src/hero/requiemroar.json
+++ b/src/hero/requiemroar.json
@@ -196,9 +196,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -420,9 +420,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.8 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1.8 * hero_atk)) * 1 * 1.871",
                 "simplified": "((3.3678 * hero_atk))",
-                "soulburn": "((2.7 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((2.7 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((5.0517 * hero_atk))"
             }
         }

--- a/src/hero/researcher-carrot.json
+++ b/src/hero/researcher-carrot.json
@@ -213,9 +213,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 0.95 * 1.871",
+                "value": "((1 * hero_atk)) * 0.95 * 1.871",
                 "simplified": "((1.7774 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 0.95 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 0.95 * 1.871",
                 "simplifiedSoulburn": "((1.7774 * hero_atk))"
             }
         },
@@ -428,9 +428,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         }
@@ -442,9 +442,9 @@
             "description": "Increases Attack by 5%.",
             "requiresRune": "",
             "skillEnhance": {
-              "rank1": "+1% Attack",
-              "rank2": "+2% Attack",
-              "rank3": "+2% Attack"
+                "rank1": "+1% Attack",
+                "rank2": "+2% Attack",
+                "rank3": "+2% Attack"
             }
         },
         {
@@ -453,9 +453,9 @@
             "description": "Increases Swing's decrease Speed effect chance by 10%.",
             "requiresRune": "",
             "skillEnhance": {
-              "rank1": "+2% effect chance",
-              "rank2": "+3% effect chance",
-              "rank3": "+5% effect chance"
+                "rank1": "+2% effect chance",
+                "rank2": "+3% effect chance",
+                "rank3": "+5% effect chance"
             }
         },
         {
@@ -464,9 +464,9 @@
             "description": "Health increases by 25%.",
             "requiresRune": "",
             "skillEnhance": {
-              "rank1": "+7% Health",
-              "rank2": "+8% Health",
-              "rank3": "+10% Health"
+                "rank1": "+7% Health",
+                "rank2": "+8% Health",
+                "rank3": "+10% Health"
             }
         },
         {
@@ -475,9 +475,9 @@
             "description": "Increases Attack by 7%.",
             "requiresRune": "Courage Rune",
             "skillEnhance": {
-              "rank1": "+2% Attack",
-              "rank2": "+2% Attack",
-              "rank3": "+3% Attack"
+                "rank1": "+2% Attack",
+                "rank2": "+2% Attack",
+                "rank3": "+3% Attack"
             }
         },
         {
@@ -486,9 +486,9 @@
             "description": "Increases Effectiveness of allies by 5%.",
             "requiresRune": "",
             "skillEnhance": {
-              "rank1": "+1% Effectiveness",
-              "rank2": "+1.5% Effectiveness",
-              "rank3": "+2.5% Effectiveness"
+                "rank1": "+1% Effectiveness",
+                "rank2": "+1.5% Effectiveness",
+                "rank3": "+2.5% Effectiveness"
             }
         },
         {
@@ -497,9 +497,9 @@
             "description": "Increases damage dealt by Flame Spurt by 10%.",
             "requiresRune": "",
             "skillEnhance": {
-              "rank1": "+2% damage dealt",
-              "rank2": "+3% damage dealt",
-              "rank3": "+5% damage dealt"
+                "rank1": "+2% damage dealt",
+                "rank2": "+3% damage dealt",
+                "rank3": "+5% damage dealt"
             }
         },
         {
@@ -508,9 +508,9 @@
             "description": "Combat Readiness increases by 10% when using Swing.",
             "requiresRune": "Sacrifice Rune",
             "skillEnhance": {
-              "rank1": "+2% Combat Readiness",
-              "rank2": "+3% Combat Readiness",
-              "rank3": "+5% Combat Readiness"
+                "rank1": "+2% Combat Readiness",
+                "rank2": "+3% Combat Readiness",
+                "rank3": "+5% Combat Readiness"
             }
         },
         {
@@ -519,9 +519,9 @@
             "description": "Has a 50% chance to dispel one debuff inflicated on the caster when Flame Barrier is activated.",
             "requiresRune": "",
             "skillEnhance": {
-              "rank1": "+10% effect chance",
-              "rank2": "+15% effect chance",
-              "rank3": "+25% effect chance"
+                "rank1": "+10% effect chance",
+                "rank2": "+15% effect chance",
+                "rank3": "+25% effect chance"
             }
         },
         {
@@ -530,9 +530,9 @@
             "description": "Increases Flame Spurt's burn effect chance by 5%.",
             "requiresRune": "Order Rune",
             "skillEnhance": {
-              "rank1": "+1% effect chance",
-              "rank2": "+1% effect chance",
-              "rank3": "+3% effect chance"
+                "rank1": "+1% effect chance",
+                "rank2": "+1% effect chance",
+                "rank3": "+3% effect chance"
             }
         },
         {
@@ -541,9 +541,9 @@
             "description": "When the caster is attacked at max Health, decreases damage received by 25%.",
             "requiresRune": "Relic Rune",
             "skillEnhance": {
-              "rank1": "-5% damage received",
-              "rank2": "-8% damage received",
-              "rank3": "-12% damage received"
+                "rank1": "-5% damage received",
+                "rank2": "-8% damage received",
+                "rank3": "-12% damage received"
             }
         }
     ],

--- a/src/hero/righteous-thief-roozid.json
+++ b/src/hero/righteous-thief-roozid.json
@@ -201,9 +201,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((spd_rate * hero_spd))) * pow! * constant",
-                "value": "((0.8 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1.0 * 1.871",
+                "value": "((0.8 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1 * 1.871",
                 "simplified": "((1.4968 * hero_atk)) * (1 + ((0.00075 * hero_spd)))",
-                "soulburn": "((0.8 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1.0 * 1.871",
+                "soulburn": "((0.8 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.4968 * hero_atk)) * (1 + ((0.00075 * hero_spd)))"
             }
         },
@@ -318,11 +318,11 @@
                 }
             ],
             "simpleDmgMod": {
-                "description": "",
-                "value": "",
-                "simplified": "",
-                "soulburn": "",
-                "simplifiedSoulburn": ""
+                "description": "((atk_rate * hero_atk)) * (1 + ((spd_rate * hero_spd))) * constant",
+                "value": "((1.2 * hero_atk)) * (1 + ((0.001125 * hero_spd))) * 1.871",
+                "simplified": "((2.2452 * hero_atk)) * (1 + ((0.001125 * hero_spd)))",
+                "soulburn": "((1.2 * hero_atk)) * (1 + ((0.001125 * hero_spd))) * 1.871",
+                "simplifiedSoulburn": "((2.2452 * hero_atk)) * (1 + ((0.001125 * hero_spd)))"
             }
         },
         {

--- a/src/hero/rikoris.json
+++ b/src/hero/rikoris.json
@@ -213,9 +213,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -424,9 +424,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.6 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.6 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.1226 * hero_atk))",
-                "soulburn": "((0.6 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((0.6 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.1226 * hero_atk))"
             }
         }

--- a/src/hero/rima.json
+++ b/src/hero/rima.json
@@ -211,9 +211,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 0.8 * 1.871",
+                "value": "((1 * hero_atk)) * 0.8 * 1.871",
                 "simplified": "((1.4968 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 0.8 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 0.8 * 1.871",
                 "simplifiedSoulburn": "((1.4968 * hero_atk))"
             }
         },

--- a/src/hero/rin.json
+++ b/src/hero/rin.json
@@ -347,9 +347,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (hp_rate * hero_hp)) * pow! * constant",
-                "value": "((0.7 * hero_atk) + (0.07 * hero_hp)) * 1.0 * 1.871",
+                "value": "((0.7 * hero_atk) + (0.07 * hero_hp)) * 1 * 1.871",
                 "simplified": "((1.3097 * hero_atk) + (0.131 * hero_hp))",
-                "soulburn": "((0.7 * hero_atk) + (0.07 * hero_hp)) * 1.0 * 1.871",
+                "soulburn": "((0.7 * hero_atk) + (0.07 * hero_hp)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.3097 * hero_atk) + (0.131 * hero_hp))"
             }
         },

--- a/src/hero/roaming-warrior-leo.json
+++ b/src/hero/roaming-warrior-leo.json
@@ -199,10 +199,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "(([1.0, 1.1] * hero_atk)) * 1 * 1.871",
-                "simplified": "(([1.871, 2.058] * hero_atk))",
-                "soulburn": "(([1.0, 1.1]1 * hero_atk)) * 1 * 1.871",
-                "simplifiedSoulburn": "(([1.871, 2.058] * hero_atk))"
+                "value": "((atk_rate[1.0, 1.1] * hero_atk)) * 1 * 1.871",
+                "simplified": "((atk_rate[1.871, 2.0581] * hero_atk))",
+                "soulburn": "((atk_rate[1.0, 1.1] * hero_atk)) * 1 * 1.871",
+                "simplifiedSoulburn": "((atk_rate[1.871, 2.0581] * hero_atk))"
             }
         },
         {
@@ -311,9 +311,9 @@
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
                 "value": "((1.2 * hero_atk)) * 1 * 1.871",
-                "simplified": "((2.245 * hero_atk))",
+                "simplified": "((2.2452 * hero_atk))",
                 "soulburn": "((1.2 * hero_atk)) * 1 * 1.871",
-                "simplifiedSoulburn": "((2.245 * hero_atk))"
+                "simplifiedSoulburn": "((2.2452 * hero_atk))"
             }
         },
         {
@@ -424,9 +424,9 @@
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
                 "value": "((0.8 * hero_atk)) * 1.1 * 1.871",
-                "simplified": "((1.647 * hero_atk))",
+                "simplified": "((1.6465 * hero_atk))",
                 "soulburn": "((0.8 * hero_atk)) * 1.1 * 1.871",
-                "simplifiedSoulburn": "((1.647 * hero_atk))"
+                "simplifiedSoulburn": "((1.6465 * hero_atk))"
             }
         }
     ],

--- a/src/hero/romann.json
+++ b/src/hero/romann.json
@@ -186,9 +186,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -297,9 +297,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.7 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.7 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.3097 * hero_atk))",
-                "soulburn": "((0.7 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((0.7 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.3097 * hero_atk))"
             }
         },

--- a/src/hero/romann.json
+++ b/src/hero/romann.json
@@ -408,18 +408,24 @@
                     "soulburn": 0.9
                 },
                 {
-                    "name": "skill_dmg_rate",
+                    "name": "target_buff_rate",
                     "description": "Increased damage if target buffed.",
-                    "value": 0.3,
-                    "soulburn": 0.3
+                    "value": [
+                        0,
+                        0.3
+                    ],
+                    "soulburn": [
+                        0,
+                        0.3
+                    ]
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((0.9 * hero_atk)) * (1 + ((0.3 * hero_special_count))) * 0.85 * 1.871",
-                "simplified": "((1.4313 * hero_atk)) * (1 + ((0.3 * hero_special_count)))",
-                "soulburn": "((0.9 * hero_atk)) * (1 + ((0.3 * hero_special_count))) * 0.85 * 1.871",
-                "simplifiedSoulburn": "((1.4313 * hero_atk)) * (1 + ((0.3 * hero_special_count)))"
+                "description": "((atk_rate * hero_atk)) * (1 + (target_buff_rate)) * pow! * constant",
+                "value": "((0.9 * hero_atk)) * (1 + ((target_buff_rate[0, 0.3]))) * 0.85 * 1.871",
+                "simplified": "((1.4313 * hero_atk)) * (1 + ((target_buff_rate[0, 0.3])))",
+                "soulburn": "((0.9 * hero_atk)) * (1 + ((target_buff_rate[0, 0.3]))) * 0.85 * 1.871",
+                "simplifiedSoulburn": "((1.4313 * hero_atk)) * (1 + ((target_buff_rate[0, 0.3])))"
             }
         }
     ],

--- a/src/hero/roozid.json
+++ b/src/hero/roozid.json
@@ -197,9 +197,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((spd_rate * hero_spd))) * pow! * constant",
-                "value": "((0.8 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1.0 * 1.871",
+                "value": "((0.8 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1 * 1.871",
                 "simplified": "((1.4968 * hero_atk)) * (1 + ((0.00075 * hero_spd)))",
-                "soulburn": "((0.8 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1.0 * 1.871",
+                "soulburn": "((0.8 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.4968 * hero_atk)) * (1 + ((0.00075 * hero_spd)))"
             }
         },
@@ -315,9 +315,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((spd_rate * hero_spd))) * pow! * constant",
-                "value": "((1.2 * hero_atk)) * (1 + ((0.001125 * hero_spd))) * 1.0 * 1.871",
+                "value": "((1.2 * hero_atk)) * (1 + ((0.001125 * hero_spd))) * 1 * 1.871",
                 "simplified": "((2.2452 * hero_atk)) * (1 + ((0.001125 * hero_spd)))",
-                "soulburn": "((1.2 * hero_atk)) * (1 + ((0.001125 * hero_spd))) * 1.0 * 1.871",
+                "soulburn": "((1.2 * hero_atk)) * (1 + ((0.001125 * hero_spd))) * 1 * 1.871",
                 "simplifiedSoulburn": "((2.2452 * hero_atk)) * (1 + ((0.001125 * hero_spd)))"
             }
         },

--- a/src/hero/rose.json
+++ b/src/hero/rose.json
@@ -199,9 +199,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (def_rate * hero_def)) * pow! * constant",
-                "value": "((0.5 * hero_atk) + (0.7 * hero_def)) * 1.0 * 1.871",
+                "value": "((0.5 * hero_atk) + (0.7 * hero_def)) * 1 * 1.871",
                 "simplified": "((0.9355 * hero_atk) + (1.3097 * hero_def))",
-                "soulburn": "((0.5 * hero_atk) + (0.7 * hero_def)) * 1.0 * 1.871",
+                "soulburn": "((0.5 * hero_atk) + (0.7 * hero_def)) * 1 * 1.871",
                 "simplifiedSoulburn": "((0.9355 * hero_atk) + (1.3097 * hero_def))"
             }
         },

--- a/src/hero/sage-baal-sezan.json
+++ b/src/hero/sage-baal-sezan.json
@@ -192,9 +192,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.1 * 1.871",
+                "value": "((1 * hero_atk)) * 1.1 * 1.871",
                 "simplified": "((2.0581 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.1 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1.1 * 1.871",
                 "simplifiedSoulburn": "((2.0581 * hero_atk))"
             }
         },
@@ -421,9 +421,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.8 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1.8 * hero_atk)) * 1 * 1.871",
                 "simplified": "((3.3678 * hero_atk))",
-                "soulburn": "((1.8 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1.8 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((3.3678 * hero_atk))"
             }
         }

--- a/src/hero/schuri.json
+++ b/src/hero/schuri.json
@@ -204,9 +204,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -426,9 +426,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         }

--- a/src/hero/serila.json
+++ b/src/hero/serila.json
@@ -190,9 +190,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -307,7 +307,7 @@
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
                 "value": "((1.5 * hero_atk)) * 1.05 * 1.871",
                 "simplified": "((2.9468 * hero_atk))",
-                "soulburn": "((2.0 * hero_atk)) * 1.05 * 1.871",
+                "soulburn": "((2 * hero_atk)) * 1.05 * 1.871",
                 "simplifiedSoulburn": "((3.9291 * hero_atk))"
             }
         },

--- a/src/hero/sez.json
+++ b/src/hero/sez.json
@@ -205,9 +205,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((target_hp_missing_rate * target_hp_lost_percent))) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * (1 + ((0.002 * target_hp_lost_percent))) * 0.95 * 1.871",
+                "value": "((1 * hero_atk)) * (1 + ((0.002 * target_hp_lost_percent))) * 0.95 * 1.871",
                 "simplified": "((1.7774 * hero_atk)) * (1 + ((0.002 * target_hp_lost_percent)))",
-                "soulburn": "((1.0 * hero_atk)) * (1 + ((0.002 * target_hp_lost_percent))) * 0.95 * 1.871",
+                "soulburn": "((1 * hero_atk)) * (1 + ((0.002 * target_hp_lost_percent))) * 0.95 * 1.871",
                 "simplifiedSoulburn": "((1.7774 * hero_atk)) * (1 + ((0.002 * target_hp_lost_percent)))"
             }
         },
@@ -317,9 +317,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.5 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.5 * hero_atk)) * 1 * 1.871",
                 "simplified": "((0.9355 * hero_atk))",
-                "soulburn": "((0.5 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((0.5 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((0.9355 * hero_atk))"
             }
         },
@@ -434,7 +434,7 @@
                 "description": "((atk_rate * hero_atk)) * (1 + ((target_hp_missing_rate * target_hp_lost_percent))) * pow! * constant",
                 "value": "((1.8 * hero_atk)) * (1 + ((0.003 * target_hp_lost_percent))) * 0.95 * 1.871",
                 "simplified": "((3.1994 * hero_atk)) * (1 + ((0.003 * target_hp_lost_percent)))",
-                "soulburn": "((1.8 * hero_atk)) * (1 + ((0.003 * target_hp_lost_percent))) * 0.95 * 1.871",
+                "soulburn": "((1.8 * hero_atk)) * (1 + ((0.007 * target_hp_lost_percent))) * 0.95 * 1.871",
                 "simplifiedSoulburn": "((3.1994 * hero_atk)) * (1 + ((0.007 * target_hp_lost_percent)))"
             }
         }

--- a/src/hero/shadow-rose.json
+++ b/src/hero/shadow-rose.json
@@ -185,9 +185,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },

--- a/src/hero/shooting-star-achates.json
+++ b/src/hero/shooting-star-achates.json
@@ -213,9 +213,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 0.95 * 1.871",
+                "value": "((1 * hero_atk)) * 0.95 * 1.871",
                 "simplified": "((1.7774 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 0.95 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 0.95 * 1.871",
                 "simplifiedSoulburn": "((1.7774 * hero_atk))"
             }
         },

--- a/src/hero/sigret.json
+++ b/src/hero/sigret.json
@@ -196,9 +196,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -310,9 +310,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.25 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1.25 * hero_atk)) * 1 * 1.871",
                 "simplified": "((2.3388 * hero_atk))",
-                "soulburn": "((1.25 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1.25 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((2.3388 * hero_atk))"
             }
         },

--- a/src/hero/silk.json
+++ b/src/hero/silk.json
@@ -248,11 +248,11 @@
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((spd_rate * hero_spd) * (skill_dmg_list))) * pow! * constant",
-                "value": "((0.9 * hero_atk)) * (1 + ((0.00075 * hero_spd) * ([0, 0, 0.03, 0.03, 0.04, 0.05]))) * 0.9 * 1.871",
-                "simplified": "((1.5155 * hero_atk)) * (1 + ((0.00075 * hero_spd) * ([0, 0, 0.03, 0.03, 0.04, 0.05])))",
-                "soulburn": "((0.9 * hero_atk)) * (1 + ((0.00075 * hero_spd) * ([0, 0, 0.03, 0.03, 0.04, 0.05]))) * 0.9 * 1.871",
-                "simplifiedSoulburn": "((1.5155 * hero_atk)) * (1 + ((0.00075 * hero_spd) * ([0, 0, 0.03, 0.03, 0.04, 0.05])))"
+                "description": "((atk_rate * hero_atk)) * (1 + ((spd_rate * hero_spd) + skill_dmg_list)) * pow! * constant",
+                "value": "((0.9 * hero_atk)) * (1 + ((0.00075 * hero_spd) + skill_dmg_list[0, 0, 0.03, 0.03, 0.04, 0.05])) * 0.9 * 1.871",
+                "simplified": "((1.5155 * hero_atk)) * (1 + ((0.00075 * hero_spd) + skill_dmg_list[0, 0, 0.03, 0.03, 0.04, 0.05]))",
+                "soulburn": "((0.9 * hero_atk)) * (1 + ((0.00075 * hero_spd) + skill_dmg_list[0, 0, 0.03, 0.03, 0.04, 0.05])) * 0.9 * 1.871",
+                "simplifiedSoulburn": "((1.5155 * hero_atk)) * (1 + ((0.00075 * hero_spd) + skill_dmg_list[0, 0, 0.03, 0.03, 0.04, 0.05]))"
             }
         },
         {

--- a/src/hero/silk.json
+++ b/src/hero/silk.json
@@ -249,10 +249,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((spd_rate * hero_spd) + skill_dmg_list)) * pow! * constant",
-                "value": "((0.9 * hero_atk)) * (1 + ((0.00075 * hero_spd) + skill_dmg_list[0, 0, 0.03, 0.03, 0.04, 0.05])) * 0.9 * 1.871",
-                "simplified": "((1.5155 * hero_atk)) * (1 + ((0.00075 * hero_spd) + skill_dmg_list[0, 0, 0.03, 0.03, 0.04, 0.05]))",
-                "soulburn": "((0.9 * hero_atk)) * (1 + ((0.00075 * hero_spd) + skill_dmg_list[0, 0, 0.03, 0.03, 0.04, 0.05])) * 0.9 * 1.871",
-                "simplifiedSoulburn": "((1.5155 * hero_atk)) * (1 + ((0.00075 * hero_spd) + skill_dmg_list[0, 0, 0.03, 0.03, 0.04, 0.05]))"
+                "value": "((0.9 * hero_atk)) * (1 + ((0.00075 * hero_spd) + (skill_dmg_list[0, 0, 0.03, 0.03, 0.04, 0.05]))) * 0.9 * 1.871",
+                "simplified": "((1.5155 * hero_atk)) * (1 + ((0.00075 * hero_spd) + (skill_dmg_list[0, 0, 0.03, 0.03, 0.04, 0.05])))",
+                "soulburn": "((0.9 * hero_atk)) * (1 + ((0.00075 * hero_spd) + (skill_dmg_list[0, 0, 0.03, 0.03, 0.04, 0.05]))) * 0.9 * 1.871",
+                "simplifiedSoulburn": "((1.5155 * hero_atk)) * (1 + ((0.00075 * hero_spd) + (skill_dmg_list[0, 0, 0.03, 0.03, 0.04, 0.05])))"
             }
         },
         {

--- a/src/hero/silver-blade-aramintha.json
+++ b/src/hero/silver-blade-aramintha.json
@@ -192,9 +192,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -303,9 +303,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.5 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.5 * hero_atk)) * 1 * 1.871",
                 "simplified": "((0.9355 * hero_atk))",
-                "soulburn": "((0.5 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((0.5 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((0.9355 * hero_atk))"
             }
         },
@@ -417,9 +417,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.9 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.9 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.6839 * hero_atk))",
-                "soulburn": "((0.9 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((0.9 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.6839 * hero_atk))"
             }
         }

--- a/src/hero/sol.json
+++ b/src/hero/sol.json
@@ -192,18 +192,24 @@
                     "soulburn": 1
                 },
                 {
-                    "name": "skill_dmg_rate",
+                    "name": "targets_rate",
                     "description": "If target has no buffs",
-                    "value": 0.2,
-                    "soulburn": 0.2
+                    "value": [
+                        0.2,
+                        0
+                    ],
+                    "soulburn": [
+                        0.2,
+                        0
+                    ]
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((1 * hero_atk)) * (1 + ((0.2 * hero_special_count))) * 1 * 1.871",
-                "simplified": "((1.871 * hero_atk)) * (1 + ((0.2 * hero_special_count)))",
-                "soulburn": "((1 * hero_atk)) * (1 + ((0.2 * hero_special_count))) * 1 * 1.871",
-                "simplifiedSoulburn": "((1.871 * hero_atk)) * (1 + ((0.2 * hero_special_count)))"
+                "description": "((atk_rate * hero_atk)) * (1 + (targets_rate)) * pow! * constant",
+                "value": "((1 * hero_atk)) * (1 + ((targets_rate[0.2, 0]))) * 1 * 1.871",
+                "simplified": "((1.871 * hero_atk)) * (1 + ((targets_rate[0.2, 0])))",
+                "soulburn": "((1 * hero_atk)) * (1 + ((targets_rate[0.2, 0]))) * 1 * 1.871",
+                "simplifiedSoulburn": "((1.871 * hero_atk)) * (1 + ((targets_rate[0.2, 0])))"
             }
         },
         {

--- a/src/hero/sol.json
+++ b/src/hero/sol.json
@@ -200,9 +200,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * (1 + ((0.2 * hero_special_count))) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * (1 + ((0.2 * hero_special_count))) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk)) * (1 + ((0.2 * hero_special_count)))",
-                "soulburn": "((1.0 * hero_atk)) * (1 + ((0.2 * hero_special_count))) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * (1 + ((0.2 * hero_special_count))) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk)) * (1 + ((0.2 * hero_special_count)))"
             }
         },
@@ -318,9 +318,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (hp_rate * hero_hp)) * pow! * constant",
-                "value": "((1.0 * hero_atk) + (0.04 * hero_hp)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk) + (0.04 * hero_hp)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk) + (0.0748 * hero_hp))",
-                "soulburn": "((1.0 * hero_atk) + (0.04 * hero_hp)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk) + (0.04 * hero_hp)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk) + (0.0748 * hero_hp))"
             }
         },
@@ -436,9 +436,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (hp_rate * hero_hp)) * pow! * constant",
-                "value": "((1.6 * hero_atk) + (0.05 * hero_hp)) * 1.0 * 1.871",
+                "value": "((1.6 * hero_atk) + (0.05 * hero_hp)) * 1 * 1.871",
                 "simplified": "((2.9936 * hero_atk) + (0.0936 * hero_hp))",
-                "soulburn": "((1.6 * hero_atk) + (0.05 * hero_hp)) * 1.0 * 1.871",
+                "soulburn": "((1.6 * hero_atk) + (0.05 * hero_hp)) * 1 * 1.871",
                 "simplifiedSoulburn": "((2.9936 * hero_atk) + (0.0936 * hero_hp))"
             }
         }

--- a/src/hero/specimen-sez.json
+++ b/src/hero/specimen-sez.json
@@ -188,9 +188,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -301,9 +301,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.8 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.8 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.4968 * hero_atk))",
-                "soulburn": "((1.05 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1.05 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.9646 * hero_atk))"
             }
         },
@@ -412,9 +412,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.5 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1.5 * hero_atk)) * 1 * 1.871",
                 "simplified": "((2.8065 * hero_atk))",
-                "soulburn": "((1.5 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1.5 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((2.8065 * hero_atk))"
             }
         }

--- a/src/hero/specter-tenebria.json
+++ b/src/hero/specter-tenebria.json
@@ -437,11 +437,11 @@
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((target_debuff_rate * target_num_debuffs))) * pow! * constant",
-                "value": "((1.8 * hero_atk)) * (1 + ((0.2 * target_num_debuffs))) * 0.95 * 1.871",
-                "simplified": "((3.1994 * hero_atk)) * (1 + ((0.2 * target_num_debuffs)))",
-                "soulburn": "((1.8 * hero_atk)) * (1 + ((0.2 * target_num_debuffs))) * 0.95 * 1.871",
-                "simplifiedSoulburn": "((3.1994 * hero_atk)) * (1 + ((0.2 * target_num_debuffs)))"
+                "description": "((atk_rate * hero_atk)) * (1 + ((target_debuff_rate * target_debuffs))) * pow! * constant",
+                "value": "((1.8 * hero_atk)) * (1 + ((0.2 * target_debuffs))) * 0.95 * 1.871",
+                "simplified": "((3.1994 * hero_atk)) * (1 + ((0.2 * target_debuffs)))",
+                "soulburn": "((1.8 * hero_atk)) * (1 + ((0.2 * target_debuffs))) * 0.95 * 1.871",
+                "simplifiedSoulburn": "((3.1994 * hero_atk)) * (1 + ((0.2 * target_debuffs)))"
             }
         }
     ],

--- a/src/hero/specter-tenebria.json
+++ b/src/hero/specter-tenebria.json
@@ -217,9 +217,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },

--- a/src/hero/specter-tenebria.json
+++ b/src/hero/specter-tenebria.json
@@ -430,18 +430,18 @@
                     "soulburn": 1.8
                 },
                 {
-                    "name": "skill_dmg_rate",
+                    "name": "target_debuff_rate",
                     "description": "Damage increased per target debuff.",
                     "value": 0.2,
                     "soulburn": 0.2
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((1.8 * hero_atk)) * (1 + ((0.2 * hero_special_count))) * 0.95 * 1.871",
-                "simplified": "((3.1994 * hero_atk)) * (1 + ((0.2 * hero_special_count)))",
-                "soulburn": "((1.8 * hero_atk)) * (1 + ((0.2 * hero_special_count))) * 0.95 * 1.871",
-                "simplifiedSoulburn": "((3.1994 * hero_atk)) * (1 + ((0.2 * hero_special_count)))"
+                "description": "((atk_rate * hero_atk)) * (1 + ((target_debuff_rate * target_num_debuffs))) * pow! * constant",
+                "value": "((1.8 * hero_atk)) * (1 + ((0.2 * target_num_debuffs))) * 0.95 * 1.871",
+                "simplified": "((3.1994 * hero_atk)) * (1 + ((0.2 * target_num_debuffs)))",
+                "soulburn": "((1.8 * hero_atk)) * (1 + ((0.2 * target_num_debuffs))) * 0.95 * 1.871",
+                "simplifiedSoulburn": "((3.1994 * hero_atk)) * (1 + ((0.2 * target_num_debuffs)))"
             }
         }
     ],

--- a/src/hero/surin.json
+++ b/src/hero/surin.json
@@ -411,30 +411,30 @@
                     "soulburn": 1.8
                 },
                 {
-                    "name": "skill_dmg_list",
+                    "name": "target_debuff_rate",
                     "description": "Damage increased per bleed.",
+                    "value": 0.15,
+                    "soulburn": 0.15
+                },
+                {
+                    "name": "target_debuff_rate",
+                    "description": "Bonus damage increased on first bleed.",
                     "value": [
-                        0.4,
-                        0.55,
-                        0.7,
-                        0.85,
-                        1
+                        0,
+                        0.25
                     ],
                     "soulburn": [
-                        0.4,
-                        0.55,
-                        0.7,
-                        0.85,
-                        1
+                        0,
+                        0.25
                     ]
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + (skill_dmg_list)) * pow! * constant",
-                "value": "((1.8 * hero_atk)) * (1 + (skill_dmg_list[0.4, 0.55, 0.7, 0.85, 1])) * 0.8 * 1.871",
-                "simplified": "((2.6942 * hero_atk)) * (1 + (skill_dmg_list[0.4, 0.55, 0.7, 0.85, 1]))",
-                "soulburn": "((1.8 * hero_atk)) * (1 + (skill_dmg_list[0.4, 0.55, 0.7, 0.85, 1])) * 0.8 * 1.871",
-                "simplifiedSoulburn": "((2.6942 * hero_atk)) * (1 + (skill_dmg_list[0.4, 0.55, 0.7, 0.85, 1]))"
+                "description": "((atk_rate * hero_atk)) * (1 + ((target_debuff_rate * target_debuffs) + target_debuff_rate)) * pow! * constant",
+                "value": "((1.8 * hero_atk)) * (1 + ((0.15 * target_debuffs) + (target_debuff_rate[0, 0.25]))) * 0.8 * 1.871",
+                "simplified": "((2.6942 * hero_atk)) * (1 + ((0.15 * target_debuffs) + (target_debuff_rate[0, 0.25])))",
+                "soulburn": "((1.8 * hero_atk)) * (1 + ((0.15 * target_debuffs) + (target_debuff_rate[0, 0.25]))) * 0.8 * 1.871",
+                "simplifiedSoulburn": "((2.6942 * hero_atk)) * (1 + ((0.15 * target_debuffs) + (target_debuff_rate[0, 0.25])))"
             }
         }
     ],

--- a/src/hero/surin.json
+++ b/src/hero/surin.json
@@ -188,9 +188,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 0.9 * 1.871",
+                "value": "((1 * hero_atk)) * 0.9 * 1.871",
                 "simplified": "((1.6839 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 0.9 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 0.9 * 1.871",
                 "simplifiedSoulburn": "((1.6839 * hero_atk))"
             }
         },
@@ -302,9 +302,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.4 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1.4 * hero_atk)) * 1 * 1.871",
                 "simplified": "((2.6194 * hero_atk))",
-                "soulburn": "((1.4 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1.4 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((2.6194 * hero_atk))"
             }
         },
@@ -430,11 +430,11 @@
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_list))) * pow! * constant",
-                "value": "((1.8 * hero_atk)) * (1 + (([0.4, 0.55, 0.7, 0.85, 1.0]))) * 0.8 * 1.871",
-                "simplified": "((2.6942 * hero_atk)) * (1 + (([0.4, 0.55, 0.7, 0.85, 1.0])))",
-                "soulburn": "((1.8 * hero_atk)) * (1 + (([0.4, 0.55, 0.7, 0.85, 1.0]))) * 0.8 * 1.871",
-                "simplifiedSoulburn": "((2.6942 * hero_atk)) * (1 + (([0.4, 0.55, 0.7, 0.85, 1.0])))"
+                "description": "((atk_rate * hero_atk)) * (1 + (skill_dmg_list)) * pow! * constant",
+                "value": "((1.8 * hero_atk)) * (1 + (skill_dmg_list[0.4, 0.55, 0.7, 0.85, 1])) * 0.8 * 1.871",
+                "simplified": "((2.6942 * hero_atk)) * (1 + (skill_dmg_list[0.4, 0.55, 0.7, 0.85, 1]))",
+                "soulburn": "((1.8 * hero_atk)) * (1 + (skill_dmg_list[0.4, 0.55, 0.7, 0.85, 1])) * 0.8 * 1.871",
+                "simplifiedSoulburn": "((2.6942 * hero_atk)) * (1 + (skill_dmg_list[0.4, 0.55, 0.7, 0.85, 1]))"
             }
         }
     ],

--- a/src/hero/sven.json
+++ b/src/hero/sven.json
@@ -177,9 +177,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 0.95 * 1.871",
+                "value": "((1 * hero_atk)) * 0.95 * 1.871",
                 "simplified": "((1.7774 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 0.95 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 0.95 * 1.871",
                 "simplifiedSoulburn": "((1.7774 * hero_atk))"
             }
         },
@@ -426,7 +426,7 @@
                 "description": "((atk_rate * hero_atk)) * (1 + ((self_hp_missing_rate * hero_hp_lost_percent))) * pow! * constant",
                 "value": "((0.8 * hero_atk)) * (1 + ((0.5 * hero_hp_lost_percent))) * 0.8 * 1.871",
                 "simplified": "((1.1974 * hero_atk)) * (1 + ((0.5 * hero_hp_lost_percent)))",
-                "soulburn": "((0.8 * hero_atk)) * (1 + ((0.5 * hero_hp_lost_percent))) * 0.8 * 1.871",
+                "soulburn": "((0.8 * hero_atk)) * (1 + ((0.65 * hero_hp_lost_percent))) * 0.8 * 1.871",
                 "simplifiedSoulburn": "((1.1974 * hero_atk)) * (1 + ((0.65 * hero_hp_lost_percent)))"
             }
         }

--- a/src/hero/tamarinne.json
+++ b/src/hero/tamarinne.json
@@ -232,10 +232,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 0.75 * 1.871",
-                "simplified": "((1.4032 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 0.75 * 1.871",
-                "simplifiedSoulburn": "((1.4032 * hero_atk))"
+                "value": "((1 * hero_atk)) * 0.75 * 1.871",
+                "simplified": "((1.4033 * hero_atk))",
+                "soulburn": "((1 * hero_atk)) * 0.75 * 1.871",
+                "simplifiedSoulburn": "((1.4033 * hero_atk))"
             }
         },
         {
@@ -567,10 +567,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 0.75 * 1.871",
-                "simplified": "((1.4032 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 0.75 * 1.871",
-                "simplifiedSoulburn": "((1.4032 * hero_atk))"
+                "value": "((1 * hero_atk)) * 0.75 * 1.871",
+                "simplified": "((1.4033 * hero_atk))",
+                "soulburn": "((1 * hero_atk)) * 0.75 * 1.871",
+                "simplifiedSoulburn": "((1.4033 * hero_atk))"
             }
         },
         {

--- a/src/hero/taranor-guard.json
+++ b/src/hero/taranor-guard.json
@@ -196,9 +196,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -420,9 +420,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.8 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1.8 * hero_atk)) * 1 * 1.871",
                 "simplified": "((3.3678 * hero_atk))",
-                "soulburn": "((1.8 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1.8 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((3.3678 * hero_atk))"
             }
         }

--- a/src/hero/taranor-royal-guard.json
+++ b/src/hero/taranor-royal-guard.json
@@ -197,9 +197,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (hp_rate * hero_hp)) * pow! * constant",
-                "value": "((0.8 * hero_atk) + (0.025 * hero_hp)) * 1.0 * 1.871",
+                "value": "((0.8 * hero_atk) + (0.025 * hero_hp)) * 1 * 1.871",
                 "simplified": "((1.4968 * hero_atk) + (0.0468 * hero_hp))",
-                "soulburn": "((0.8 * hero_atk) + (0.025 * hero_hp)) * 1.0 * 1.871",
+                "soulburn": "((0.8 * hero_atk) + (0.025 * hero_hp)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.4968 * hero_atk) + (0.0468 * hero_hp))"
             }
         },

--- a/src/hero/tenebria.json
+++ b/src/hero/tenebria.json
@@ -200,9 +200,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -311,9 +311,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.8 * hero_atk)) * 1.0 * 1.871",
+                "value": "((0.8 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.4968 * hero_atk))",
-                "soulburn": "((0.8 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((0.8 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.4968 * hero_atk))"
             }
         },

--- a/src/hero/tieria.json
+++ b/src/hero/tieria.json
@@ -171,9 +171,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.05 * 1.871",
+                "value": "((1 * hero_atk)) * 1.05 * 1.871",
                 "simplified": "((1.9646 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.05 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1.05 * 1.871",
                 "simplifiedSoulburn": "((1.9646 * hero_atk))"
             }
         },

--- a/src/hero/vildred.json
+++ b/src/hero/vildred.json
@@ -432,9 +432,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((spd_rate * hero_spd))) * pow! * constant",
-                "value": "((0.85 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1.0 * 1.871",
+                "value": "((0.85 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1 * 1.871",
                 "simplified": "((1.5903 * hero_atk)) * (1 + ((0.00075 * hero_spd)))",
-                "soulburn": "((1.1 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1.0 * 1.871",
+                "soulburn": "((1.1 * hero_atk)) * (1 + ((0.0009 * hero_spd))) * 1 * 1.871",
                 "simplifiedSoulburn": "((2.0581 * hero_atk)) * (1 + ((0.0009 * hero_spd)))"
             }
         }

--- a/src/hero/violet.json
+++ b/src/hero/violet.json
@@ -226,9 +226,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 0.9 * 1.871",
+                "value": "((1 * hero_atk)) * 0.9 * 1.871",
                 "simplified": "((1.6839 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 0.9 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 0.9 * 1.871",
                 "simplifiedSoulburn": "((1.6839 * hero_atk))"
             }
         },

--- a/src/hero/vivian.json
+++ b/src/hero/vivian.json
@@ -209,21 +209,23 @@
             "damageModifiers": [
                 {
                     "name": "pow",
-                    "section": "pow",
                     "value": 1,
                     "soulburn": 1
                 },
                 {
-                    "name": "statModifier",
+                    "name": "atk_rate",
                     "description": "",
-                    "section": "additive",
-                    "stat": "atk",
-                    "type": "multiplier",
-                    "target": "self",
                     "value": 1.2,
                     "soulburn": 1.2
                 }
-            ]
+            ],
+            "simpleDmgMod": {
+                "description": "((atk_rate * hero_atk)) * pow! * constant",
+                "value": "((1.2 * hero_atk)) * 1 * 1.871",
+                "simplified": "((2.2452 * hero_atk))",
+                "soulburn": "((1.2 * hero_atk)) * 1 * 1.871",
+                "simplifiedSoulburn": "((2.2452 * hero_atk))"
+            }
         },
         {
             "isPassive": false,
@@ -349,21 +351,23 @@
             "damageModifiers": [
                 {
                     "name": "pow",
-                    "section": "pow",
                     "value": 0.9,
                     "soulburn": 0.9
                 },
                 {
-                    "name": "statModifier",
+                    "name": "atk_rate",
                     "description": "",
-                    "section": "additive",
-                    "stat": "atk",
-                    "type": "multiplier",
-                    "target": "self",
                     "value": 1.05,
                     "soulburn": 1.3
                 }
-            ]
+            ],
+            "simpleDmgMod": {
+                "description": "((atk_rate * hero_atk)) * pow! * constant",
+                "value": "((1.05 * hero_atk)) * 0.9 * 1.871",
+                "simplified": "((1.7681 * hero_atk))",
+                "soulburn": "((1.3 * hero_atk)) * 0.9 * 1.871",
+                "simplifiedSoulburn": "((2.1891 * hero_atk))"
+            }
         },
         {
             "isPassive": false,
@@ -403,21 +407,23 @@
             "damageModifiers": [
                 {
                     "name": "pow",
-                    "section": "pow",
                     "value": 0,
                     "soulburn": 0
                 },
                 {
-                    "name": "statModifier",
+                    "name": "atk_rate",
                     "description": "",
-                    "section": "additive",
-                    "stat": "atk",
-                    "type": "multiplier",
-                    "target": "self",
                     "value": 0,
                     "soulburn": 0
                 }
-            ]
+            ],
+            "simpleDmgMod": {
+                "description": "",
+                "value": "",
+                "simplified": "",
+                "soulburn": "",
+                "simplifiedSoulburn": ""
+            }
         }
     ],
     "specialtySkill": {

--- a/src/hero/wanda.json
+++ b/src/hero/wanda.json
@@ -218,11 +218,11 @@
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((target_debuff_rate * target_num_debuffs))) * pow! * constant",
-                "value": "((0.9 * hero_atk)) * (1 + ((0.35 * target_num_debuffs))) * 0.95 * 1.871",
-                "simplified": "((1.5997 * hero_atk)) * (1 + ((0.35 * target_num_debuffs)))",
-                "soulburn": "((0.9 * hero_atk)) * (1 + ((0.35 * target_num_debuffs))) * 0.95 * 1.871",
-                "simplifiedSoulburn": "((1.5997 * hero_atk)) * (1 + ((0.35 * target_num_debuffs)))"
+                "description": "((atk_rate * hero_atk)) * (1 + ((target_debuff_rate * target_debuffs))) * pow! * constant",
+                "value": "((0.9 * hero_atk)) * (1 + ((0.35 * target_debuffs))) * 0.95 * 1.871",
+                "simplified": "((1.5997 * hero_atk)) * (1 + ((0.35 * target_debuffs)))",
+                "soulburn": "((0.9 * hero_atk)) * (1 + ((0.35 * target_debuffs))) * 0.95 * 1.871",
+                "simplifiedSoulburn": "((1.5997 * hero_atk)) * (1 + ((0.35 * target_debuffs)))"
             }
         },
         {

--- a/src/hero/wanda.json
+++ b/src/hero/wanda.json
@@ -211,18 +211,18 @@
                     "soulburn": 0.9
                 },
                 {
-                    "name": "skill_dmg_rate",
-                    "description": "Increased damage if enemy is targetted.",
+                    "name": "target_debuff_rate",
+                    "description": "Increased damage if enemy is targetted. Max once.",
                     "value": 0.35,
                     "soulburn": 0.35
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((0.9 * hero_atk)) * (1 + ((0.35 * hero_special_count))) * 0.95 * 1.871",
-                "simplified": "((1.5997 * hero_atk)) * (1 + ((0.35 * hero_special_count)))",
-                "soulburn": "((0.9 * hero_atk)) * (1 + ((0.35 * hero_special_count))) * 0.95 * 1.871",
-                "simplifiedSoulburn": "((1.5997 * hero_atk)) * (1 + ((0.35 * hero_special_count)))"
+                "description": "((atk_rate * hero_atk)) * (1 + ((target_debuff_rate * target_num_debuffs))) * pow! * constant",
+                "value": "((0.9 * hero_atk)) * (1 + ((0.35 * target_num_debuffs))) * 0.95 * 1.871",
+                "simplified": "((1.5997 * hero_atk)) * (1 + ((0.35 * target_num_debuffs)))",
+                "soulburn": "((0.9 * hero_atk)) * (1 + ((0.35 * target_num_debuffs))) * 0.95 * 1.871",
+                "simplifiedSoulburn": "((1.5997 * hero_atk)) * (1 + ((0.35 * target_num_debuffs)))"
             }
         },
         {

--- a/src/hero/wanderer-silk.json
+++ b/src/hero/wanderer-silk.json
@@ -189,9 +189,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((spd_rate * hero_spd))) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk)) * (1 + ((0.00075 * hero_spd)))",
-                "soulburn": "((1.0 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk)) * (1 + ((0.00075 * hero_spd)))"
             }
         },
@@ -305,9 +305,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((spd_rate * hero_spd))) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 0.9 * 1.871",
+                "value": "((1 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 0.9 * 1.871",
                 "simplified": "((1.6839 * hero_atk)) * (1 + ((0.00075 * hero_spd)))",
-                "soulburn": "((1.0 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 0.9 * 1.871",
+                "soulburn": "((1 * hero_atk)) * (1 + ((0.00075 * hero_spd))) * 0.9 * 1.871",
                 "simplifiedSoulburn": "((1.6839 * hero_atk)) * (1 + ((0.00075 * hero_spd)))"
             }
         },

--- a/src/hero/watcher-schuri.json
+++ b/src/hero/watcher-schuri.json
@@ -188,9 +188,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },

--- a/src/hero/yufine.json
+++ b/src/hero/yufine.json
@@ -213,9 +213,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         },
@@ -303,10 +303,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((0.9 * hero_atk)) * 1.0 * 1.871",
-                "simplified": "((1.684 * hero_atk))",
-                "soulburn": "((0.9 * hero_atk)) * 1.0 * 1.871",
-                "simplifiedSoulburn": "((1.684 * hero_atk))"
+                "value": "((0.9 * hero_atk)) * 1 * 1.871",
+                "simplified": "((1.6839 * hero_atk))",
+                "soulburn": "((0.9 * hero_atk)) * 1 * 1.871",
+                "simplifiedSoulburn": "((1.6839 * hero_atk))"
             }
         },
         {
@@ -439,9 +439,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((2.0 * hero_atk)) * (1 + ((0.5 * hero_special_count))) * 0.95 * 1.871",
+                "value": "((2 * hero_atk)) * (1 + ((0.5 * hero_special_count))) * 0.95 * 1.871",
                 "simplified": "((3.5549 * hero_atk)) * (1 + ((0.5 * hero_special_count)))",
-                "soulburn": "((2.0 * hero_atk)) * (1 + ((0.5 * hero_special_count))) * 0.95 * 1.871",
+                "soulburn": "((2 * hero_atk)) * (1 + ((0.5 * hero_special_count))) * 0.95 * 1.871",
                 "simplifiedSoulburn": "((3.5549 * hero_atk)) * (1 + ((0.5 * hero_special_count)))"
             }
         }

--- a/src/hero/yufine.json
+++ b/src/hero/yufine.json
@@ -431,18 +431,24 @@
                     "soulburn": 2
                 },
                 {
-                    "name": "skill_dmg_rate",
+                    "name": "target_buff_rate",
                     "description": "If target is buffed, increases damage.",
-                    "value": 0.5,
-                    "soulburn": 0.5
+                    "value": [
+                        0,
+                        0.5
+                    ],
+                    "soulburn": [
+                        0,
+                        0.5
+                    ]
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((2 * hero_atk)) * (1 + ((0.5 * hero_special_count))) * 0.95 * 1.871",
-                "simplified": "((3.5549 * hero_atk)) * (1 + ((0.5 * hero_special_count)))",
-                "soulburn": "((2 * hero_atk)) * (1 + ((0.5 * hero_special_count))) * 0.95 * 1.871",
-                "simplifiedSoulburn": "((3.5549 * hero_atk)) * (1 + ((0.5 * hero_special_count)))"
+                "description": "((atk_rate * hero_atk)) * (1 + (target_buff_rate)) * pow! * constant",
+                "value": "((2 * hero_atk)) * (1 + ((target_buff_rate[0, 0.5]))) * 0.95 * 1.871",
+                "simplified": "((3.5549 * hero_atk)) * (1 + ((target_buff_rate[0, 0.5])))",
+                "soulburn": "((2 * hero_atk)) * (1 + ((target_buff_rate[0, 0.5]))) * 0.95 * 1.871",
+                "simplifiedSoulburn": "((3.5549 * hero_atk)) * (1 + ((target_buff_rate[0, 0.5])))"
             }
         }
     ],

--- a/src/hero/yuna.json
+++ b/src/hero/yuna.json
@@ -229,12 +229,14 @@
                     "name": "targets_rate",
                     "description": "Increased damage based number of targets.",
                     "value": [
+                        0,
                         1.6,
                         1.4,
                         0,
                         0
                     ],
                     "soulburn": [
+                        0,
                         1.6,
                         1.4,
                         0,
@@ -244,10 +246,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((spd_rate * hero_spd) + targets_rate)) * pow! * constant",
-                "value": "((0.6 * hero_atk)) * (1 + ((0.00075 * hero_spd) + (targets_rate[1.6, 1.4, 0, 0]))) * 0.8 * 1.871",
-                "simplified": "((0.8981 * hero_atk)) * (1 + ((0.00075 * hero_spd) + (targets_rate[1.6, 1.4, 0, 0])))",
-                "soulburn": "((0.85 * hero_atk)) * (1 + ((0.00075 * hero_spd) + (targets_rate[1.6, 1.4, 0, 0]))) * 0.8 * 1.871",
-                "simplifiedSoulburn": "((1.2723 * hero_atk)) * (1 + ((0.00075 * hero_spd) + (targets_rate[1.6, 1.4, 0, 0])))"
+                "value": "((0.6 * hero_atk)) * (1 + ((0.00075 * hero_spd) + (targets_rate[0, 1.6, 1.4, 0, 0]))) * 0.8 * 1.871",
+                "simplified": "((0.8981 * hero_atk)) * (1 + ((0.00075 * hero_spd) + (targets_rate[0, 1.6, 1.4, 0, 0])))",
+                "soulburn": "((0.85 * hero_atk)) * (1 + ((0.00075 * hero_spd) + (targets_rate[0, 1.6, 1.4, 0, 0]))) * 0.8 * 1.871",
+                "simplifiedSoulburn": "((1.2723 * hero_atk)) * (1 + ((0.00075 * hero_spd) + (targets_rate[0, 1.6, 1.4, 0, 0])))"
             }
         },
         {

--- a/src/hero/yuna.json
+++ b/src/hero/yuna.json
@@ -226,26 +226,28 @@
                     "soulburn": 0.00075
                 },
                 {
-                    "name": "skill_dmg_rate",
+                    "name": "targets_rate",
                     "description": "Increased damage based number of targets.",
                     "value": [
                         1.6,
                         1.4,
+                        0,
                         0
                     ],
                     "soulburn": [
                         1.6,
                         1.4,
+                        0,
                         0
                     ]
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((spd_rate * hero_spd) + (skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((0.6 * hero_atk)) * (1 + ((0.00075 * hero_spd) + (skill_dmg_rate[1.6, 1.4, 0] * hero_special_count))) * 0.8 * 1.871",
-                "simplified": "((0.8981 * hero_atk)) * (1 + ((0.00075 * hero_spd) + (skill_dmg_rate[1.6, 1.4, 0] * hero_special_count)))",
-                "soulburn": "((0.85 * hero_atk)) * (1 + ((0.00075 * hero_spd) + (skill_dmg_rate[1.6, 1.4, 0] * hero_special_count))) * 0.8 * 1.871",
-                "simplifiedSoulburn": "((1.2723 * hero_atk)) * (1 + ((0.00075 * hero_spd) + (skill_dmg_rate[1.6, 1.4, 0] * hero_special_count)))"
+                "description": "((atk_rate * hero_atk)) * (1 + ((spd_rate * hero_spd) + targets_rate)) * pow! * constant",
+                "value": "((0.6 * hero_atk)) * (1 + ((0.00075 * hero_spd) + (targets_rate[1.6, 1.4, 0, 0]))) * 0.8 * 1.871",
+                "simplified": "((0.8981 * hero_atk)) * (1 + ((0.00075 * hero_spd) + (targets_rate[1.6, 1.4, 0, 0])))",
+                "soulburn": "((0.85 * hero_atk)) * (1 + ((0.00075 * hero_spd) + (targets_rate[1.6, 1.4, 0, 0]))) * 0.8 * 1.871",
+                "simplifiedSoulburn": "((1.2723 * hero_atk)) * (1 + ((0.00075 * hero_spd) + (targets_rate[1.6, 1.4, 0, 0])))"
             }
         },
         {

--- a/src/hero/yuna.json
+++ b/src/hero/yuna.json
@@ -242,10 +242,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((spd_rate * hero_spd) + (skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((0.6 * hero_atk)) * (1 + ((0.00075 * hero_spd) + ([1.6, 1.4, 0.0] * hero_special_count))) * 0.8 * 1.871",
-                "simplified": "((0.8981 * hero_atk)) * (1 + ((0.00075 * hero_spd) + ([1.6, 1.4, 0.0] * hero_special_count)))",
-                "soulburn": "((0.85 * hero_atk)) * (1 + ((0.00075 * hero_spd) + ([1.6, 1.4, 0.0] * hero_special_count))) * 0.8 * 1.871",
-                "simplifiedSoulburn": "((1.2723 * hero_atk)) * (1 + ((0.00075 * hero_spd) + ([1.6, 1.4, 0.0] * hero_special_count)))"
+                "value": "((0.6 * hero_atk)) * (1 + ((0.00075 * hero_spd) + (skill_dmg_rate[1.6, 1.4, 0] * hero_special_count))) * 0.8 * 1.871",
+                "simplified": "((0.8981 * hero_atk)) * (1 + ((0.00075 * hero_spd) + (skill_dmg_rate[1.6, 1.4, 0] * hero_special_count)))",
+                "soulburn": "((0.85 * hero_atk)) * (1 + ((0.00075 * hero_spd) + (skill_dmg_rate[1.6, 1.4, 0] * hero_special_count))) * 0.8 * 1.871",
+                "simplifiedSoulburn": "((1.2723 * hero_atk)) * (1 + ((0.00075 * hero_spd) + (skill_dmg_rate[1.6, 1.4, 0] * hero_special_count)))"
             }
         },
         {
@@ -468,10 +468,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((1.5 * hero_atk)) * (1 + (([1.6, 1.4, 0.0] * hero_special_count))) * 0.8 * 1.871",
-                "simplified": "((2.2452 * hero_atk)) * (1 + (([1.6, 1.4, 0.0] * hero_special_count)))",
-                "soulburn": "((1.5 * hero_atk)) * (1 + (([1.6, 1.4, 0.0] * hero_special_count))) * 0.8 * 1.871",
-                "simplifiedSoulburn": "((2.2452 * hero_atk)) * (1 + (([1.6, 1.4, 0.0] * hero_special_count)))"
+                "value": "((1.5 * hero_atk)) * (1 + ((skill_dmg_rate[1.6, 1.4, 0] * hero_special_count))) * 0.8 * 1.871",
+                "simplified": "((2.2452 * hero_atk)) * (1 + ((skill_dmg_rate[1.6, 1.4, 0] * hero_special_count)))",
+                "soulburn": "((1.5 * hero_atk)) * (1 + ((skill_dmg_rate[1.6, 1.4, 0] * hero_special_count))) * 0.8 * 1.871",
+                "simplifiedSoulburn": "((2.2452 * hero_atk)) * (1 + ((skill_dmg_rate[1.6, 1.4, 0] * hero_special_count)))"
             }
         }
     ],

--- a/src/hero/zeno.json
+++ b/src/hero/zeno.json
@@ -193,9 +193,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (hp_rate * hero_hp)) * pow! * constant",
-                "value": "((0.5 * hero_atk) + (0.1 * hero_hp)) * 1.0 * 1.871",
+                "value": "((0.5 * hero_atk) + (0.1 * hero_hp)) * 1 * 1.871",
                 "simplified": "((0.9355 * hero_atk) + (0.1871 * hero_hp))",
-                "soulburn": "((0.5 * hero_atk) + (0.1 * hero_hp)) * 1.0 * 1.871",
+                "soulburn": "((0.5 * hero_atk) + (0.1 * hero_hp)) * 1 * 1.871",
                 "simplifiedSoulburn": "((0.9355 * hero_atk) + (0.1871 * hero_hp))"
             }
         },
@@ -434,10 +434,10 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk) + (hp_rate * hero_hp)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((0.5 * hero_atk) + (0.12 * hero_hp)) * (1 + (([0.05, 0.08] * hero_special_count))) * 1.0 * 1.871",
-                "simplified": "((0.9355 * hero_atk) + (0.2245 * hero_hp)) * (1 + (([0.05, 0.08] * hero_special_count)))",
-                "soulburn": "((0.5 * hero_atk) + (0.12 * hero_hp)) * (1 + (([0.05, 0.08] * hero_special_count))) * 1.0 * 1.871",
-                "simplifiedSoulburn": "((0.9355 * hero_atk) + (0.2245 * hero_hp)) * (1 + (([0.05, 0.08] * hero_special_count)))"
+                "value": "((0.5 * hero_atk) + (0.12 * hero_hp)) * (1 + ((skill_dmg_rate[0.05, 0.08] * hero_special_count))) * 1 * 1.871",
+                "simplified": "((0.9355 * hero_atk) + (0.2245 * hero_hp)) * (1 + ((skill_dmg_rate[0.05, 0.08] * hero_special_count)))",
+                "soulburn": "((0.5 * hero_atk) + (0.12 * hero_hp)) * (1 + ((skill_dmg_rate[0.05, 0.08] * hero_special_count))) * 1 * 1.871",
+                "simplifiedSoulburn": "((0.9355 * hero_atk) + (0.2245 * hero_hp)) * (1 + ((skill_dmg_rate[0.05, 0.08] * hero_special_count)))"
             }
         }
     ],

--- a/src/hero/zerato.json
+++ b/src/hero/zerato.json
@@ -279,18 +279,18 @@
                     "soulburn": 2
                 },
                 {
-                    "name": "skill_dmg_rate",
-                    "description": "Increased damage if target is debuffed.",
+                    "name": "target_debuff_rate",
+                    "description": "Increased damage if target is debuffed. Max once.",
                     "value": 0.3,
                     "soulburn": 0.3
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
-                "value": "((1.5 * hero_atk)) * (1 + ((0.3 * hero_special_count))) * 0.95 * 1.871",
-                "simplified": "((2.6662 * hero_atk)) * (1 + ((0.3 * hero_special_count)))",
-                "soulburn": "((2 * hero_atk)) * (1 + ((0.3 * hero_special_count))) * 0.95 * 1.871",
-                "simplifiedSoulburn": "((3.5549 * hero_atk)) * (1 + ((0.3 * hero_special_count)))"
+                "description": "((atk_rate * hero_atk)) * (1 + ((target_debuff_rate * target_num_debuffs))) * pow! * constant",
+                "value": "((1.5 * hero_atk)) * (1 + ((0.3 * target_num_debuffs))) * 0.95 * 1.871",
+                "simplified": "((2.6662 * hero_atk)) * (1 + ((0.3 * target_num_debuffs)))",
+                "soulburn": "((2 * hero_atk)) * (1 + ((0.3 * target_num_debuffs))) * 0.95 * 1.871",
+                "simplifiedSoulburn": "((3.5549 * hero_atk)) * (1 + ((0.3 * target_num_debuffs)))"
             }
         },
         {

--- a/src/hero/zerato.json
+++ b/src/hero/zerato.json
@@ -286,11 +286,11 @@
                 }
             ],
             "simpleDmgMod": {
-                "description": "((atk_rate * hero_atk)) * (1 + ((target_debuff_rate * target_num_debuffs))) * pow! * constant",
-                "value": "((1.5 * hero_atk)) * (1 + ((0.3 * target_num_debuffs))) * 0.95 * 1.871",
-                "simplified": "((2.6662 * hero_atk)) * (1 + ((0.3 * target_num_debuffs)))",
-                "soulburn": "((2 * hero_atk)) * (1 + ((0.3 * target_num_debuffs))) * 0.95 * 1.871",
-                "simplifiedSoulburn": "((3.5549 * hero_atk)) * (1 + ((0.3 * target_num_debuffs)))"
+                "description": "((atk_rate * hero_atk)) * (1 + ((target_debuff_rate * target_debuffs))) * pow! * constant",
+                "value": "((1.5 * hero_atk)) * (1 + ((0.3 * target_debuffs))) * 0.95 * 1.871",
+                "simplified": "((2.6662 * hero_atk)) * (1 + ((0.3 * target_debuffs)))",
+                "soulburn": "((2 * hero_atk)) * (1 + ((0.3 * target_debuffs))) * 0.95 * 1.871",
+                "simplifiedSoulburn": "((3.5549 * hero_atk)) * (1 + ((0.3 * target_debuffs)))"
             }
         },
         {

--- a/src/hero/zerato.json
+++ b/src/hero/zerato.json
@@ -183,9 +183,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.05 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1.05 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.9646 * hero_atk))",
-                "soulburn": "((1.05 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1.05 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.9646 * hero_atk))"
             }
         },
@@ -289,7 +289,7 @@
                 "description": "((atk_rate * hero_atk)) * (1 + ((skill_dmg_rate * hero_special_count))) * pow! * constant",
                 "value": "((1.5 * hero_atk)) * (1 + ((0.3 * hero_special_count))) * 0.95 * 1.871",
                 "simplified": "((2.6662 * hero_atk)) * (1 + ((0.3 * hero_special_count)))",
-                "soulburn": "((2.0 * hero_atk)) * (1 + ((0.3 * hero_special_count))) * 0.95 * 1.871",
+                "soulburn": "((2 * hero_atk)) * (1 + ((0.3 * hero_special_count))) * 0.95 * 1.871",
                 "simplifiedSoulburn": "((3.5549 * hero_atk)) * (1 + ((0.3 * hero_special_count)))"
             }
         },
@@ -430,9 +430,9 @@
             ],
             "simpleDmgMod": {
                 "description": "((atk_rate * hero_atk)) * pow! * constant",
-                "value": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "value": "((1 * hero_atk)) * 1 * 1.871",
                 "simplified": "((1.871 * hero_atk))",
-                "soulburn": "((1.0 * hero_atk)) * 1.0 * 1.871",
+                "soulburn": "((1 * hero_atk)) * 1 * 1.871",
                 "simplifiedSoulburn": "((1.871 * hero_atk))"
             }
         }


### PR DESCRIPTION
Also fixed #216

I fixed up my script to handle generation with the less common modifiers.

Broke some of hero_special_count types out into more detail.
target_buff_rate
target_debuff_rate
targets_rate

I changed the lists [] to be a bit more readable, I think. Rather than just a [], I added the variable name in front to tell what the list is.

Yuna example
"simplified": "((0.8981 * hero_atk)) * (1 + ((0.00075 * hero_spd) + (targets_rate[1.6, 1.4, 0, 0])))",


Also the Cidd modifier math was wrong, so script fixed that. I needed special code for him as he is more complex due to his S2.