### PR TITLE
October 30 2019 patch

### DIFF
--- a/src/artifact/bloody-rose.json
+++ b/src/artifact/bloody-rose.json
@@ -1,0 +1,27 @@
+{
+    "name": "Bloody Rose (preview)",
+    "rarity": 4,
+    "exclusive": [
+        "mage"
+    ],
+    "event": "",
+    "loreDescription": [
+        "\"I will steal that power from him and bring my family back from the dead, then he too will learn how it feels to lose everything. Just watch me.\""
+    ],
+    "skillDescription": {
+        "base": "Increases Effectiveness by 30% on a Single Attack.",
+        "max": "Increases Effectiveness by 60% on a Single Attack."
+    },
+    "stats": {
+        "base": {
+            "atk": 21,
+            "hp": 32
+        },
+        "max": {
+            "atk": 273,
+            "hp": 416
+        }
+    },
+    "buffs": [],
+    "debuffs": []
+}

--- a/src/artifact/bloody-rose.json
+++ b/src/artifact/bloody-rose.json
@@ -1,6 +1,6 @@
 {
     "name": "Bloody Rose (preview)",
-    "rarity": 4,
+    "rarity": 5,
     "exclusive": [
         "mage"
     ],

--- a/src/artifact/draco-plate.json
+++ b/src/artifact/draco-plate.json
@@ -1,0 +1,30 @@
+{
+    "name": "Draco Plate",
+    "rarity": 5,
+    "exclusive": [
+        "warrior"
+    ],
+    "event": "the-shadow-of-ravenwing-manor",
+    "loreDescription": [
+        "\"Isn't it ironic? That Dragon's skin and bones are now used to make armor to protect the very Dragon Knights of Wintenberg it cursed as it died.\" The queen laughed as she wiped the blood from her armor."
+    ],
+    "skillDescription": {
+        "base": "Increases Critical Hit Damage by 15.0% while decreasing damage suffered from critical hits by 8.0%. When more than one similar effect is granted, only the strongest effect is applied.",
+        "max": "Increases Critical Hit Damage by 30.0% while decreasing damage suffered from critical hits by 16.0%. When more than one similar effect is granted, only the strongest effect is applied."
+    },
+    "stats": {
+        "base": {
+            "atk": 15,
+            "hp": 54
+        },
+        "max": {
+            "atk": 195,
+            "hp": 702
+        }
+    },
+    "buffs": [
+        "stic_cri_dmg_up",
+        "stic_cri_res_up"
+    ],
+    "debuffs": []
+}

--- a/src/hero/arowell.json
+++ b/src/hero/arowell.json
@@ -95,7 +95,7 @@
             "cooldown": 0,
             "name": "Shield Thrust",
             "soulAcquire": 1,
-            "description": "Attacks with a sword and a shield, with a 50% chance to dispel one buff. Damage dealt increases proportional to the caster's max Health.",
+            "description": "Attacks with a sword and a shield, with a 50% chance to dispel two buffs. Damage dealt increases proportional to the caster's max Health.",
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
@@ -228,7 +228,7 @@
             "cooldown": 0,
             "name": "Escort",
             "soulAcquire": 0,
-            "description": "Grants a barrier for 2 turns to the ally with the lowest Health at beginning of the turn. Barrier strength increases proportional to the caster's max Health.",
+            "description": "Grants a barrier to the ally with the lowest Health for 2 turns at the beginning of the battle and each time the caster takes a turn. Barrier strength increases proportional to the caster's max Health.",
             "enhancement": [
                 {
                     "description": "+2% barrier strength",

--- a/src/hero/assassin-cidd.json
+++ b/src/hero/assassin-cidd.json
@@ -99,7 +99,7 @@
             "cooldown": 0,
             "name": "Slice",
             "soulAcquire": 1,
-            "description": "Attacks with an axe, with a 40% chance to poison for 2 turns. Damage dealt increases proportional to the caster's Speed.",
+            "description": "Attacks with an axe, with a 40% chance to decrease Defense for 2 turns. Damage dealt increases proportional to the caster's Speed.",
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
@@ -198,7 +198,7 @@
             ],
             "buffs": [],
             "debuffs": [
-                "stic_dot"
+                "stic_def_dn"
             ],
             "damageModifiers": [
                 {
@@ -321,7 +321,7 @@
             "cooldown": 4,
             "name": "Execution",
             "soulAcquire": 2,
-            "description": "Attacks the enemy with a powerful ground pound, silencing them for 1 turn and decreasing their Combat Readiness by 50%. Damage dealt increases proportional to the caster and the enemy's Speed.",
+            "description": "Attacks the enemy with a powerful ground pound, silencing them for 1 turn and decreasing their Combat Readiness by 50%, before increasing Evasion Chance of the caster for 2 turns. Damage dealt increases proportional to the caster and the enemy’s speed.\nRemoves 20 Souls from the opponent.",
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
@@ -418,9 +418,13 @@
                     ]
                 }
             ],
-            "buffs": [],
+            "buffs": [
+                "stic_dodge_up"
+            ],
             "debuffs": [
-                "stic_silence"
+                "stic_silence",
+                "efct_cr_dn",
+                "efct_soul_dn"
             ],
             "damageModifiers": [
                 {

--- a/src/hero/champion-zerato.json
+++ b/src/hero/champion-zerato.json
@@ -99,7 +99,7 @@
             "cooldown": 0,
             "name": "Earthen Rage",
             "soulAcquire": 1,
-            "description": "Attacks the enemy with an earthen blast, transferring one debuff from the caster to the enemy.",
+            "description": "Attacks two enemies including the target with an earthen blast, transferring two debuffs from the caster to the enemy and recovering the caster's Health. Amount recovered increases proportional to the caster's max Health.",
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
@@ -227,7 +227,7 @@
             "cooldown": 0,
             "name": "Iron Will",
             "soulAcquire": 0,
-            "description": "Immune to stun and sleep. Has a 80% chance to counterattack when attacked while debuffed.",
+            "description": "Immune to stun, sleep, and Decrease Hit Chance. Has a 80% chance to counterattack when attacked while debuffed.",
             "enhancement": [
                 {
                     "description": "+5% activation chance",
@@ -312,7 +312,7 @@
             "cooldown": 5,
             "name": "Cataclysm",
             "soulAcquire": 3,
-            "description": "Attacks all enemies by slamming rocks, with a 60% chance each to decrease Defense and Attack for 2 turns.",
+            "description": "Attacks all enemies by slamming rocks, with a 60% chance each to decrease Defense and Attack for 2 turns. Increases Defense of the caster for 2 turns.",
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
@@ -409,7 +409,9 @@
                     ]
                 }
             ],
-            "buffs": [],
+            "buffs": [
+                "stic_def_up",
+            ],
             "debuffs": [
                 "stic_def_dn",
                 "stic_att_dn"

--- a/src/hero/champion-zerato.json
+++ b/src/hero/champion-zerato.json
@@ -410,7 +410,7 @@
                 }
             ],
             "buffs": [
-                "stic_def_up",
+                "stic_def_up"
             ],
             "debuffs": [
                 "stic_def_dn",

--- a/src/hero/corvus.json
+++ b/src/hero/corvus.json
@@ -97,13 +97,13 @@
         {
             "isPassive": false,
             "soulBurn": 0,
-            "selfSkillBarValue": 0,
+            "selfSkillBarValue": 10,
             "soulBurnEffect": "",
             "awakenUpgrade": false,
             "cooldown": 0,
             "name": "Shield Slam",
             "soulAcquire": 1,
-            "description": "Shoves the enemy with a shield, with a 50% chance to transfer one debuff from the caster to the enemy. Damage dealt increases proportional to the caster's Defense.",
+            "description": "Shoves the enemy with a shield, with a 50% chance to transfer one debuff from the caster to the enemy. When the caster is enraged, damage dealt is increased and the enemy is stunned for 1 turn. Damage dealt increases proportional to the caster's Defense.",
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
@@ -201,7 +201,10 @@
                 }
             ],
             "buffs": [],
-            "debuffs": [],
+            "debuffs": [
+                "efct_trans",
+                "stic_stun"
+            ],
             "damageModifiers": [
                 {
                     "name": "pow",
@@ -244,13 +247,13 @@
         {
             "isPassive": false,
             "soulBurn": 0,
-            "selfSkillBarValue": 0,
+            "selfSkillBarValue": 30,
             "soulBurnEffect": "",
             "awakenUpgrade": false,
             "cooldown": 4,
             "name": "Macerate",
             "soulAcquire": 2,
-            "description": "Attacks all enemies with an iron mace, decreasing Combat Readiness by 20%. When the enemy's Combat Readiness is 0, stuns for 1 turn. Damage dealt increases proportional to the caster's Defense.",
+            "description": "Attacks all enemies with an iron mace, decreasing Combat Readiness by 20%. When the enemy's Combat Readiness is 0, stuns for 1 turn. When the caster is enraged, doubles the amount of Combat Readiness decrease. Damage dealt increases proportional to the caster's Defense.",
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
@@ -392,13 +395,13 @@
         {
             "isPassive": false,
             "soulBurn": 20,
-            "selfSkillBarValue": -50,
+            "selfSkillBarValue": -100,
             "soulBurnEffect": "Amount of Health recovered is doubled.",
             "awakenUpgrade": true,
             "cooldown": 0,
             "name": "Fury's Advent",
             "soulAcquire": 2,
-            "description": "Strengthens the caster with fighting spirit for 3 turns, recovering Health, and increasing Defense for 3 turns. Grants extra turn.\nShield Slam: Increases Damage dealt, stunning for 1 turn.\nMacerate: Decreases the enemy's Combat Readiness twice.\nAcquires 10 Fighting Spirit when attacking or attacked.",
+            "description": "The caster becomes enraged with Fighting Spirit for 3 turns, recovering Health, before granting an extra turn.\nBegins the first battle with 50 Fighting Spirit.\nGains 10 Fighting Spirit when attacked.",
             "enhancement": [
                 {
                     "description": "+2 Soul acquired",
@@ -436,11 +439,10 @@
                 }
             ],
             "buffs": [
-                "stic_def_up"
+                "stic_enraged",
+                "efct_ex_turn"
             ],
-            "debuffs": [
-                "stic_stun"
-            ],
+            "debuffs": [],
             "damageModifiers": [
                 {
                     "name": "pow",

--- a/src/hero/dominiel.json
+++ b/src/hero/dominiel.json
@@ -296,7 +296,7 @@
             "cooldown": 5,
             "name": "Ice Spear",
             "soulAcquire": 2,
-            "description": "Attacks all enemies with a large block of ice, with a 35% chance each to stun for 1 turn and decrease Combat Readiness by 30%.",
+            "description": "Attacks all enemies with a large block of ice, with a 75% chance to stun for 1 turn and a 35% chance to decrease Combat Readiness by 30%.",
             "enhancement": [
                 {
                     "description": "+5% damage dealt",

--- a/src/hero/elson.json
+++ b/src/hero/elson.json
@@ -222,7 +222,7 @@
             "selfSkillBarValue": 0,
             "soulBurnEffect": "",
             "awakenUpgrade": false,
-            "cooldown": 4,
+            "cooldown": 3,
             "name": "Meteor Shower",
             "soulAcquire": 2,
             "description": "Attacks all enemies with Meteor Shower of Light and recovers the Health of all allies. Healing increases proportional to the ally's max Health.",
@@ -363,10 +363,10 @@
             "selfSkillBarValue": 0,
             "soulBurnEffect": "Extends buff duration by 1 turn.",
             "awakenUpgrade": true,
-            "cooldown": 6,
+            "cooldown": 5,
             "name": "Light's Protection",
             "soulAcquire": 1,
-            "description": "Increases Attack and Defense of all allies for 2 turns with buffing magic.",
+            "description": "Recovers Health and increases Attack and Defense of all allies for 2 turns with strengthening magic. Amount recovered increases proportional to the target's max Health.",
             "enhancement": [
                 {
                     "description": "+2 Soul acquired",

--- a/src/hero/melissa.json
+++ b/src/hero/melissa.json
@@ -1,0 +1,673 @@
+{
+    "gameId": "",
+    "name": "Melissa (preview)",
+    "rarity": 5,
+    "classType": "mage",
+    "element": "fire",
+    "zodiac": "leo",
+    "specialtyChangeName": "",
+    "selfSkillBarName": "",
+    "background": "A Vampire who dreams of revenge after losing everything. Originally the eldest daughter of a noble family, she fell in love with a Vampire she met at a ball and soon became a Vampire herself. After a long separation following an ambush, she was enraged to discover her love had betrayed her. Though he had since died, that won't stop her exacting her revenge on his son.",
+    "relations": [
+        {
+            "hero": "",
+            "relationType": ""
+        }
+    ],
+    "stats": {
+        "lv1BaseStarNoAwaken": {
+            "cp": 1451,
+            "atk": 110,
+            "hp": 229,
+            "spd": 106,
+            "def": 80,
+            "chc": 0.15,
+            "chd": 1.5,
+            "eff": 0,
+            "efr": 0,
+            "dac": 0.05
+        },
+        "lv50FiveStarNoAwaken": {
+            "cp": 11710,
+            "atk": 880,
+            "hp": 3045,
+            "spd": 106,
+            "def": 520,
+            "chc": 0.15,
+            "chd": 1.5,
+            "eff": 0,
+            "efr": 0,
+            "dac": 0.05
+        },
+        "lv50FiveStarFullyAwakened": {
+            "cp": 13169,
+            "atk": 1079,
+            "hp": 3385,
+            "spd": 112,
+            "def": 520,
+            "chc": 0.15,
+            "chd": 1.5,
+            "eff": 0,
+            "efr": 0,
+            "dac": 0.05
+        },
+        "lv60SixStarNoAwaken": {
+            "cp": 14604,
+            "atk": 1098,
+            "hp": 3828,
+            "spd": 106,
+            "def": 645,
+            "chc": 0.15,
+            "chd": 1.5,
+            "eff": 0,
+            "efr": 0,
+            "dac": 0.05
+        },
+        "lv60SixStarFullyAwakened": {
+            "cp": 16722,
+            "atk": 1412,
+            "hp": 4248,
+            "spd": 112,
+            "def": 645,
+            "chc": 0.15,
+            "chd": 1.5,
+            "eff": 0,
+            "efr": 0,
+            "dac": 0.05
+        }
+    },
+    "skills": [
+        {
+            "isPassive": false,
+            "soulBurn": 0,
+            "selfSkillBarValue": 0,
+            "soulBurnEffect": "Increases damage dealt.",
+            "awakenUpgrade": false,
+            "cooldown": 0,
+            "name": "Might",
+            "soulAcquire": 0,
+            "description": "Overpowers the enemy, with a 60% chance to make them unhealable for 1 turn. Damage dealt increases proportional to the caster's lost Health.",
+            "enhancement": [
+                {
+                    "description": "",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        }
+                    ]
+                },
+                {
+                    "description": "",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        }
+                    ]
+                },
+                {
+                    "description": "",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 29000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "twisted-fang",
+                            "qty": 5
+                        }
+                    ]
+                },
+                {
+                    "description": "",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 47000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "twisted-fang",
+                            "qty": 7
+                        }
+                    ]
+                },
+                {
+                    "description": "",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 80000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "blazing-soul",
+                            "qty": 2
+                        }
+                    ]
+                }
+            ],
+            "buffs": [],
+            "debuffs": [
+                "stic_heal_impossible"
+            ],
+            "damageModifiers": [
+                {
+                    "name": "pow",
+                    "value": 1.1,
+                    "soulburn": 1.1
+                },
+                {
+                    "name": "atk_rate",
+                    "value": 1,
+                    "soulburn": 1.5
+                },
+                {
+                    "name": "self_hp_missing_rate",
+                    "value": 0.0035,
+                    "soulburn": 0.0035
+                }
+            ],
+            "simpleDmgMod": {
+                "description": "((atk_rate * hero_atk)) * (1 + ((self_hp_missing_rate * hero_hp_lost_percent))) * pow! * constant",
+                "value": "((1 * hero_atk)) * (1 + ((0.0035 * hero_hp_lost_percent))) * 1.1 * 1.871",
+                "simplified": "((2.0581 * hero_atk)) * (1 + ((0.0035 * hero_hp_lost_percent)))",
+                "soulburn": "((1.5 * hero_atk)) * (1 + ((0.0035 * hero_hp_lost_percent))) * 1.1 * 1.871",
+                "simplifiedSoulburn": "((3.08715 * hero_atk)) * (1 + ((0.0035 * hero_hp_lost_percent)))"
+            }
+        },
+        {
+            "isPassive": false,
+            "soulBurn": 0,
+            "selfSkillBarValue": 0,
+            "soulBurnEffect": "",
+            "awakenUpgrade": false,
+            "cooldown": 0,
+            "name": "Manifestation",
+            "soulAcquire": 0,
+            "description": "Attacks by unleashing their inner rage, granting immortality to the caster for 1 turn.",
+            "enhancement": [
+                {
+                    "description": "",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        }
+                    ]
+                },
+                {
+                    "description": "",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        }
+                    ]
+                },
+                {
+                    "description": "",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 29000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "twisted-fang",
+                            "qty": 5
+                        }
+                    ]
+                },
+                {
+                    "description": "",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 47000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "twisted-fang",
+                            "qty": 7
+                        }
+                    ]
+                },
+                {
+                    "description": "",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 80000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "blazing-soul",
+                            "qty": 2
+                        }
+                    ]
+                }
+            ],
+            "buffs": [
+                "stic_invincible"
+            ],
+            "debuffs": [],
+            "damageModifiers": [
+                {
+                    "name": "pow",
+                    "value": 0.95,
+                    "soulburn": 0.95
+                },
+                {
+                    "name": "atk_rate",
+                    "value": 1.5,
+                    "soulburn": 1.5
+                }
+            ],
+            "simpleDmgMod": {
+                "description": "((atk_rate * hero_atk)) * pow! * constant",
+                "value": "((1.5 * hero_atk)) * 0.95 * 1.871",
+                "simplified": "((2.6662 * hero_atk))",
+                "soulburn": "((1.5 * hero_atk)) * 0.95 * 1.871",
+                "simplifiedSoulburn": "((2.6662 * hero_atk))"
+            }
+        },
+        {
+            "isPassive": false,
+            "soulBurn": 0,
+            "selfSkillBarValue": 0,
+            "soulBurnEffect": "",
+            "awakenUpgrade": true,
+            "cooldown": 0,
+            "name": "Blood Bloom",
+            "soulAcquire": 0,
+            "description": "Attacks by releasing their pent-up aggression, cursing the enemy for 2 turns, with a critical hit granting the caster an extra turn. This skill is unaffected by elemental disadvantage. Elite or Boss monster cannot be cursed.",
+            "enhancement": [
+                {
+                    "description": "",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        }
+                    ]
+                },
+                {
+                    "description": "",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 4000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        }
+                    ]
+                },
+                {
+                    "description": "",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 29000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "twisted-fang",
+                            "qty": 5
+                        }
+                    ]
+                },
+                {
+                    "description": "",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 47000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 3
+                        },
+                        {
+                            "item": "twisted-fang",
+                            "qty": 7
+                        }
+                    ]
+                },
+                {
+                    "description": "",
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 80000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 5
+                        },
+                        {
+                            "item": "blazing-soul",
+                            "qty": 2
+                        }
+                    ]
+                }
+            ],
+            "buffs": [
+                "efct_ex_turn"
+            ],
+            "debuffs": [
+                "stic_curse"
+            ],
+            "damageModifiers": [
+                {
+                    "name": "pow",
+                    "value": 1,
+                    "soulburn": 1
+                },
+                {
+                    "name": "atk_rate",
+                    "value": 1.2,
+                    "soulburn": 1.2
+                }
+            ],
+            "simpleDmgMod": {
+                "description": "((atk_rate * hero_atk)) * pow! * constant",
+                "value": "((1.2 * hero_atk)) * 1 * 1.871",
+                "simplified": "((2.2452 * hero_atk))",
+                "soulburn": "((1.2 * hero_atk)) * 1 * 1.871",
+                "simplifiedSoulburn": "((2.2452 * hero_atk))"
+            }
+        }
+    ],
+    "specialtySkill": {
+        "name": "",
+        "description": "",
+        "dispatch": [],
+        "enhancement": [],
+        "stats": {
+            "command": 0,
+            "charm": 0,
+            "politics": 0
+        }
+    },
+    "camping": {
+        "options": [
+            "occult",
+            "food-story"
+        ],
+        "reactions": {
+            "advice": 0,
+            "belief": 0,
+            "bizarre-story": 0,
+            "comforting-cheer": 0,
+            "complain": 0,
+            "criticism": 0,
+            "cute-cheer": 0,
+            "dream": 0,
+            "food-story": 0,
+            "gossip": 0,
+            "happy-memory": 0,
+            "heroic-cheer": 0,
+            "heroic-tale": 0,
+            "horror-story": 0,
+            "interesting-story": 0,
+            "joyful-memory": 0,
+            "myth": 0,
+            "occult": 0,
+            "reality-check": 0,
+            "sad-memory": 0,
+            "self-indulgent": 0,
+            "unique-comment": 0
+        }
+    },
+    "memoryImprintFormation": {
+        "north": true,
+        "south": true,
+        "east": true,
+        "west": true
+    },
+    "memoryImprintAttribute": "eff%",
+    "memoryImprint": [
+        {
+            "rank": "d",
+            "status": {
+                "type": "eff",
+                "increase": 0
+            }
+        },
+        {
+            "rank": "c",
+            "status": {
+                "type": "eff",
+                "increase": 0
+            }
+        },
+        {
+            "rank": "b",
+            "status": {
+                "type": "eff",
+                "increase": 0.048
+            }
+        },
+        {
+            "rank": "a",
+            "status": {
+                "type": "eff",
+                "increase": 0.072
+            }
+        },
+        {
+            "rank": "s",
+            "status": {
+                "type": "eff",
+                "increase": 0.096
+            }
+        },
+        {
+            "rank": "ss",
+            "status": {
+                "type": "eff",
+                "increase": 0.12
+            }
+        },
+        {
+            "rank": "sss",
+            "status": {
+                "type": "eff",
+                "increase": 0.144
+            }
+        }
+    ],
+    "awakening": [
+        {
+            "rank": 1,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "spd": 2
+                },
+                {
+                    "atk": 20
+                },
+                {
+                    "hp": 60
+                }
+            ],
+            "resources": [
+                {
+                    "item": "flame-rune",
+                    "qty": 10
+                }
+            ]
+        },
+        {
+            "rank": 2,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "atk": 0.03
+                },
+                {
+                    "atk": 20
+                },
+                {
+                    "hp": 60
+                }
+            ],
+            "resources": [
+                {
+                    "item": "flame-rune",
+                    "qty": 15
+                },
+                {
+                    "item": "greater-flame-rune",
+                    "qty": 2
+                }
+            ]
+        },
+        {
+            "rank": 3,
+            "skillUpgrade": true,
+            "statsIncrease": [
+                {
+                    "atk": 20
+                },
+                {
+                    "hp": 60
+                }
+            ],
+            "resources": [
+                {
+                    "item": "flame-rune",
+                    "qty": 20
+                },
+                {
+                    "item": "greater-flame-rune",
+                    "qty": 10
+                }
+            ]
+        },
+        {
+            "rank": 4,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "atk": 0.06
+                },
+                {
+                    "atk": 30
+                },
+                {
+                    "hp": 80
+                }
+            ],
+            "resources": [
+                {
+                    "item": "greater-flame-rune",
+                    "qty": 10
+                },
+                {
+                    "item": "epic-flame-rune",
+                    "qty": 2
+                }
+            ]
+        },
+        {
+            "rank": 5,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "spd": 4
+                },
+                {
+                    "atk": 30
+                },
+                {
+                    "hp": 80
+                }
+            ],
+            "resources": [
+                {
+                    "item": "epic-flame-rune",
+                    "qty": 6
+                },
+                {
+                    "item": "ultra-fang",
+                    "qty": 15
+                }
+            ]
+        },
+        {
+            "rank": 6,
+            "skillUpgrade": false,
+            "statsIncrease": [
+                {
+                    "atk": 0.06
+                },
+                {
+                    "atk": 30
+                },
+                {
+                    "hp": 80
+                }
+            ],
+            "resources": [
+                {
+                    "item": "epic-flame-rune",
+                    "qty": 10
+                },
+                {
+                    "item": "blazing-soul",
+                    "qty": 10
+                }
+            ]
+        }
+    ],
+    "summonQuote": "",
+    "description": ""
+}

--- a/src/hero/mirsa.json
+++ b/src/hero/mirsa.json
@@ -234,7 +234,7 @@
             "cooldown": 0,
             "name": "Brush Off",
             "soulAcquire": 0,
-            "description": "Increases Evasion. When Health is less than 50%, effect is increased by an extra 15%. After successfully evading, the caster is granted increased Speed for 2 turns, and their cooldown decreases by 1 turn.",
+            "description": "Increases Evasion Chance by 35%. After successfully evading, decreases cooldown of the caster by 1 turn and increases Speed for 2 turns.",
             "enhancement": [
                 {
                     "description": "+5% Evasion Chance",

--- a/src/hero/rin.json
+++ b/src/hero/rin.json
@@ -365,7 +365,7 @@
             "cooldown": 5,
             "name": "Showtime",
             "soulAcquire": 2,
-            "description": "Heals all allies with an elegant dance, casting two random buffs for 3 turns. Amount recovered and barrier strength is proportional to the target's max Health.",
+            "description": "Heals all allies with an elegant dance, granting two random buff for 3 turns. Amount recovered increases proportional to the target's max Health.",
             "enhancement": [
                 {
                     "description": "+15% healing",

--- a/src/hero/rin.json
+++ b/src/hero/rin.json
@@ -95,7 +95,7 @@
             "cooldown": 0,
             "name": "Ring Throw",
             "soulAcquire": 1,
-            "description": "Throws rings at the enemy, with a 75% chance to dispel one buff. Damage dealt increases proportional to the caster's max Health.",
+            "description": "Throws rings at the enemy, with a 75% chance to dispel one buff, before increasing the caster's Combat Readiness by 15%. Damage dealt increases proportional to the caster's max Health.",
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
@@ -192,7 +192,9 @@
                     ]
                 }
             ],
-            "buffs": [],
+            "buffs": [
+                "efct_cr_up"
+            ],
             "debuffs": [],
             "damageModifiers": [
                 {

--- a/src/hero/specimen-sez.json
+++ b/src/hero/specimen-sez.json
@@ -204,7 +204,7 @@
             "cooldown": 3,
             "name": "Evil Claw",
             "soulAcquire": 2,
-            "description": "Attacks all enemies with evil claws, with a 30% chance to stun for 1 turn, before increasing the caster's Combat Readiness by 50%.",
+            "description": "Attacks all enemies with evil claws, with a 45% chance to stun for 1 turn, before increasing the caster's Combat Readiness by 50%.",
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
@@ -317,7 +317,7 @@
             "cooldown": 5,
             "name": "Light Storm",
             "soulAcquire": 3,
-            "description": "Attacks the enemy with a light storm. If the enemy is stunned, penetrates their Defense. Skill cooldown is reset if the enemy is defeated.",
+            "description": "Attacks the enemy with a light storm, inflicting extinction and resetting cooldown for this skill when the enemy is defeated. Penetrates Defense by 30%, or by 100% when the enemy is stunned.",
             "enhancement": [
                 {
                     "description": "+5% damage dealt",
@@ -398,7 +398,10 @@
                 }
             ],
             "buffs": [],
-            "debuffs": [],
+            "debuffs": [
+                "efct_extinct",
+                "efct_def_pen"
+            ],
             "damageModifiers": [
                 {
                     "name": "pow",

--- a/src/hero/tenebria.json
+++ b/src/hero/tenebria.json
@@ -216,7 +216,7 @@
             "cooldown": 3,
             "name": "Ominous Thunder",
             "soulAcquire": 2,
-            "description": "Summons ominous thunder to attack all enemies, decreasing Combat Readiness by 20%.",
+            "description": "Summons ominous thunder to attack all enemies, decreasing Combat Readiness by 20%, before decreasing Speed for 2 turns.",
             "enhancement": [
                 {
                     "description": "+5% damage dealt ",
@@ -296,8 +296,12 @@
                     ]
                 }
             ],
-            "buffs": [],
-            "debuffs": [],
+            "buffs": [
+                "stic_speed_up"
+            ],
+            "debuffs": [
+                "efct_cr_dn"
+            ],
             "damageModifiers": [
                 {
                     "name": "pow",
@@ -327,7 +331,7 @@
             "cooldown": 5,
             "name": "Nightmare",
             "soulAcquire": 3,
-            "description": "Drops Moon of Nightmare on all enemies, with a 70% chance to decrease Defense for 2 turns and increase Attack of the caster for 2 turns.",
+            "description": "Drops Moon of Nightmare on all enemies, with a 70% chance to decrease Defense for 2 turns, and a 60% (Maximum 75%) chance to put them to sleep for 1 turn, before increasing Attack of the caster for 2 turns.",
             "enhancement": [
                 {
                     "description": "+10% damage dealt",
@@ -411,7 +415,8 @@
                 "stic_att_up"
             ],
             "debuffs": [
-                "stic_def_dn"
+                "stic_def_dn",
+                "stic_sleep"
             ],
             "damageModifiers": [
                 {

--- a/src/hero/troublemaker-crozet.json
+++ b/src/hero/troublemaker-crozet.json
@@ -31,7 +31,7 @@
         "lv1BaseStarNoAwaken": {
             "cp": 1252,
             "atk": 59,
-            "hp": 0298,
+            "hp": 298,
             "spd": 98,
             "def": 77,
             "chc": 0.15,

--- a/src/hero/troublemaker-crozet.json
+++ b/src/hero/troublemaker-crozet.json
@@ -1,6 +1,7 @@
 {
     "gameId": "c2036",
     "name": "Troublemaker Crozet",
+    "surname": "",
     "rarity": 4,
     "classType": "knight",
     "element": "dark",
@@ -386,7 +387,20 @@
             "enhancement": [
                 {
                     "description": "-1 turn cooldown",
-                    "resources": []
+                    "resources": [
+                        {
+                            "item": "gold",
+                            "qty": 44000
+                        },
+                        {
+                            "item": "molagora",
+                            "qty": 1
+                        },
+                        {
+                            "item": "strange-jelly",
+                            "qty": 8
+                        }
+                    ]
                 }
             ],
             "buffs": [

--- a/src/hero/troublemaker-crozet.json
+++ b/src/hero/troublemaker-crozet.json
@@ -1,6 +1,6 @@
 {
     "gameId": "c2036",
-    "name": "Troublemaker Crozet (preview)",
+    "name": "Troublemaker Crozet",
     "rarity": 4,
     "classType": "knight",
     "element": "dark",
@@ -10,17 +10,29 @@
     "background": "Crozet's Moonlight Shade who does as he pleases with no consideration for anyone around him. Because he does whatever he wants, he's caused a lot of trouble, which has led Crozet himself to come looking for Troublemaker Crozet.",
     "relations": [
         {
-            "hero": "",
-            "relationType": ""
+            "hero": "crozet",
+            "relationType": "hostile"
+        },
+        {
+            "hero": "maya",
+            "relationType": "love"
+        },
+        {
+            "hero": "lorina",
+            "relationType": "love"
+        },
+        {
+            "hero": "jena",
+            "relationType": "love"
         }
     ],
     "stats": {
         "lv1BaseStarNoAwaken": {
-            "cp": 0,
-            "atk": 0,
-            "hp": 0,
-            "spd": 0,
-            "def": 0,
+            "cp": 1252,
+            "atk": 59,
+            "hp": 0298,
+            "spd": 98,
+            "def": 77,
             "chc": 0.15,
             "chd": 1.5,
             "eff": 0,
@@ -28,11 +40,11 @@
             "dac": 0.05
         },
         "lv50FiveStarNoAwaken": {
-            "cp": 0,
-            "atk": 0,
-            "hp": 0,
-            "spd": 0,
-            "def": 0,
+            "cp": 11167,
+            "atk": 502,
+            "hp": 4202,
+            "spd": 98,
+            "def": 531,
             "chc": 0.15,
             "chd": 1.5,
             "eff": 0,
@@ -40,23 +52,23 @@
             "dac": 0.05
         },
         "lv50FiveStarFullyAwakened": {
-            "cp": 0,
-            "atk": 0,
-            "hp": 0,
-            "spd": 0,
-            "def": 0,
+            "cp": 12870,
+            "atk": 622,
+            "hp": 4794,
+            "spd": 98,
+            "def": 578,
             "chc": 0.15,
             "chd": 1.5,
             "eff": 0,
-            "efr": 0,
+            "efr": 0.06,
             "dac": 0.05
         },
         "lv60SixStarNoAwaken": {
-            "cp": 0,
-            "atk": 0,
-            "hp": 0,
-            "spd": 0,
-            "def": 0,
+            "cp": 13940,
+            "atk": 626,
+            "hp": 5284,
+            "spd": 98,
+            "def": 659,
             "chc": 0.15,
             "chd": 1.5,
             "eff": 0,
@@ -64,15 +76,15 @@
             "dac": 0.05
         },
         "lv60SixStarFullyAwakened": {
-            "cp": 0,
-            "atk": 0,
-            "hp": 0,
-            "spd": 0,
-            "def": 0,
+            "cp": 16543,
+            "atk": 776,
+            "hp": 6021,
+            "spd": 98,
+            "def": 718,
             "chc": 0.15,
             "chd": 1.5,
             "eff": 0,
-            "efr": 0,
+            "efr": 0.18,
             "dac": 0.05
         }
     },
@@ -406,14 +418,14 @@
         }
     ],
     "specialtySkill": {
-        "name": "Lion and Shield",
-        "description": "",
-        "dispatch": "[War] Category",
-        "enhancement": "Time Required -6%",
+        "name": "Flame of Passion",
+        "description": "Today marks the day he told the 486th girl that he loves her.",
+        "dispatch": "[Security] Type",
+        "enhancement": "Reward Bonus +6%",
         "stats": {
-            "command": 0,
-            "charm": 0,
-            "politics": 0
+            "command": 72,
+            "charm": 97,
+            "politics": 43
         }
     },
     "camping": {


### PR DESCRIPTION
Damage modifiers need updating for this.

- The damage for the skill “Dark Explosion” will be increased by 20% compared to before.